### PR TITLE
Add teams that own repos to Repo object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       "dependencies": {
         "@types/jest": "^28.1.6",
         "@types/node": "^18.6.3",
+        "dotenv": "^16.0.1",
         "jest": "^28.1.3",
         "ts-jest": "^28.0.7",
         "ts-node": "^10.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2653,9 +2653,9 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -3133,9 +3133,9 @@
       "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg=="
     },
     "node_modules/@types/prettier": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.4.tgz",
-      "integrity": "sha512-fOwvpvQYStpb/zHMx0Cauwywu9yLDmzWiiQBC7gJyq5tYLUXFZvDG7VK1B7WBxxjBJNKFOZ0zLoOQn8vmATbhw=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.0.tgz",
+      "integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A=="
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -6122,6 +6122,15 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/jest-runtime": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-28.1.3.tgz",
@@ -7262,15 +7271,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/sprintf-js": {
@@ -10245,9 +10245,9 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -10659,9 +10659,9 @@
       "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg=="
     },
     "@types/prettier": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.4.tgz",
-      "integrity": "sha512-fOwvpvQYStpb/zHMx0Cauwywu9yLDmzWiiQBC7gJyq5tYLUXFZvDG7VK1B7WBxxjBJNKFOZ0zLoOQn8vmATbhw=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.0.tgz",
+      "integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A=="
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -12708,6 +12708,17 @@
         "jest-worker": "^28.1.3",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
+      },
+      "dependencies": {
+        "source-map-support": {
+          "version": "0.5.13",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+          "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
       }
     },
     "jest-runtime": {
@@ -13552,15 +13563,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-    },
-    "source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@types/jest": "^28.1.6",
     "@types/node": "^18.6.3",
+    "dotenv": "^16.0.1",
     "jest": "^28.1.3",
     "ts-jest": "^28.0.7",
     "ts-node": "^10.9.1",

--- a/packages/common/github/github.ts
+++ b/packages/common/github/github.ts
@@ -96,9 +96,10 @@ export const listTeams = async (config: Config): Promise<TeamsResponse> => {
 
 export const getReposForTeam = async (config: Config, teamName: string): Promise<TeamRepoResponse> => {
     const octokit = await getOctokit(config);
-    const request =  await octokit.request("GET /orgs/guardian/teams/{team}/repos", {
-        team: teamName,
+    const request =  await octokit.paginate(octokit.teams.listReposInOrg, {
+        org: "guardian",
+        team_slug: teamName,
         per_page: defaultPageSize,
-      });
-    return request.data;
+      }, response => response.data);
+    return request;
 };

--- a/packages/common/github/github.ts
+++ b/packages/common/github/github.ts
@@ -21,6 +21,12 @@ const octokit = new Octokit();
 export type RepositoriesResponse = GetResponseDataTypeFromEndpointMethod<
     typeof octokit.repos.listForOrg
     >;
+export type TeamsResponse = GetResponseDataTypeFromEndpointMethod<
+typeof octokit.teams.list
+>;
+export type TeamRepoResponse = GetResponseDataTypeFromEndpointMethod<
+typeof octokit.teams.listReposInOrg
+>;
 export type RepositoryResponse = RepositoriesResponse[number];
 
 let _octokit: Octokit | undefined;
@@ -77,4 +83,22 @@ export const listRepositories = async (config: Config): Promise<RepositoriesResp
             org: 'guardian',
             per_page: defaultPageSize,
         }, (response) => response.data);
+};
+
+export const listTeams = async (config: Config): Promise<TeamsResponse> => {
+    const octokit = await getOctokit(config);
+    return await octokit.paginate(
+        octokit.teams.list, {
+            org: 'guardian',
+            per_page: defaultPageSize,
+        }, (response) => response.data);
+};
+
+export const getReposForTeam = async (config: Config, teamName: string): Promise<TeamRepoResponse> => {
+    const octokit = await getOctokit(config);
+    const request =  await octokit.request("GET /orgs/guardian/teams/{team}/repos", {
+        team: teamName,
+        per_page: defaultPageSize,
+      });
+    return request.data;
 };

--- a/packages/repo-fetcher/package.json
+++ b/packages/repo-fetcher/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "A fetcher for repository metadata in your GitHub organisation",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects repo-fetcher",
     "build": "esbuild src/*.ts --bundle --outdir=dist --platform=node --target=node16 --external:aws-sdk",
     "esbuild": "esbuild",
     "dev": "../../node_modules/.bin/ts-node ./src/handler"

--- a/packages/repo-fetcher/src/handler.ts
+++ b/packages/repo-fetcher/src/handler.ts
@@ -2,7 +2,7 @@ import config from "../../common/config";
 import { listRepositories, RepositoriesResponse, RepositoryResponse, listTeams} from "../../common/github/github";
 import { putItem } from "../../common/aws/s3";
 import {createOwnerObjects, findOwnersOfRepo, RepoAndOwner} from "../src/transformations"
-interface Repository {
+export interface Repository {
     id: number,
     name: string,
     full_name: string,
@@ -28,7 +28,7 @@ const parseDateString = (dateString: string | null | undefined): Date | null => 
     return new Date(dateString);
 }
 
-const transformRepo = (repo: RepositoryResponse, owners: string[]): Repository => {
+export const transformRepo = (repo: RepositoryResponse, owners: string[]): Repository => {
 
     return {
         id: repo.id,

--- a/packages/repo-fetcher/src/handler.ts
+++ b/packages/repo-fetcher/src/handler.ts
@@ -1,68 +1,13 @@
 import { putItem } from '../../common/aws/s3';
 import { config } from '../../common/config';
-import type {
-	RepositoriesResponse,
-	RepositoryResponse,
-} from '../../common/github/github';
+import type { RepositoriesResponse } from '../../common/github/github';
 import { listRepositories, listTeams } from '../../common/github/github';
-import type { RepoAndOwner } from '../src/transformations';
-import { createOwnerObjects, findOwnersOfRepo } from '../src/transformations';
-
-export interface Repository {
-	id: number;
-	name: string;
-	full_name: string;
-	private: boolean;
-	description: string | null;
-	created_at: Date | null;
-	updated_at: Date | null;
-	pushed_at: Date | null;
-	size: number | undefined;
-	language: string | null | undefined;
-	archived: boolean | undefined;
-	open_issues_count: number | undefined;
-	is_template: boolean | undefined;
-	topics: string[] | undefined;
-	default_branch: string | undefined;
-	owners: string[];
-}
-
-const parseDateString = (
-	dateString: string | null | undefined,
-): Date | null => {
-	if (
-		dateString === undefined ||
-		dateString === null ||
-		dateString.length === 0
-	) {
-		return null;
-	}
-	return new Date(dateString);
-};
-
-export const transformRepo = (
-	repo: RepositoryResponse,
-	owners: string[],
-): Repository => {
-	return {
-		id: repo.id,
-		name: repo.name,
-		full_name: repo.full_name,
-		private: repo.private,
-		description: repo.description,
-		created_at: parseDateString(repo.created_at),
-		updated_at: parseDateString(repo.updated_at),
-		pushed_at: parseDateString(repo.pushed_at),
-		size: repo.size,
-		language: repo.language,
-		archived: repo.archived,
-		open_issues_count: repo.open_issues_count,
-		is_template: repo.is_template,
-		topics: repo.topics,
-		default_branch: repo.default_branch,
-		owners: owners,
-	};
-};
+import type { RepoAndOwner, Repository } from '../src/transformations';
+import {
+	createOwnerObjects,
+	findOwnersOfRepo,
+	transformRepo,
+} from '../src/transformations';
 
 const save = (repos: Repository[]): Promise<void> => {
 	const prefix = config.dataKeyPrefix;

--- a/packages/repo-fetcher/src/mockRepo.ts
+++ b/packages/repo-fetcher/src/mockRepo.ts
@@ -1,0 +1,119 @@
+export const mockRepo = {
+	id: 123456,
+	node_id: 'MDEwOlJlcG9zaXRvcnkxMjk2MjY5',
+	name: 'repo-name',
+	full_name: 'guardian/repo-name',
+	owner: {
+		login: 'guardian',
+		id: 1,
+		node_id: 'MDQ6VXNlcjE=',
+		avatar_url: 'https://github.com/images/error/octocat_happy.gif',
+		gravatar_id: '',
+		url: 'https://api.github.com/users/octocat',
+		html_url: 'https://github.com/octocat',
+		followers_url: 'https://api.github.com/users/octocat/followers',
+		following_url:
+			'https://api.github.com/users/octocat/following{/other_user}',
+		gists_url: 'https://api.github.com/users/octocat/gists{/gist_id}',
+		starred_url: 'https://api.github.com/users/octocat/starred{/owner}{/repo}',
+		subscriptions_url: 'https://api.github.com/users/octocat/subscriptions',
+		organizations_url: 'https://api.github.com/users/octocat/orgs',
+		repos_url: 'https://api.github.com/users/octocat/repos',
+		events_url: 'https://api.github.com/users/octocat/events{/privacy}',
+		received_events_url: 'https://api.github.com/users/octocat/received_events',
+		type: 'User',
+		site_admin: false,
+	},
+	private: false,
+	html_url: 'https://github.com/guardian/repo-name',
+	description: 'This your first repo!',
+	fork: false,
+	url: 'https://api.github.com/repos/guardian/repo-name',
+	archive_url:
+		'https://api.github.com/repos/guardian/repo-name/{archive_format}{/ref}',
+	assignees_url:
+		'https://api.github.com/repos/guardian/repo-name/assignees{/user}',
+	blobs_url: 'https://api.github.com/repos/guardian/repo-name/git/blobs{/sha}',
+	branches_url:
+		'https://api.github.com/repos/guardian/repo-name/branches{/branch}',
+	collaborators_url:
+		'https://api.github.com/repos/guardian/repo-name/collaborators{/collaborator}',
+	comments_url:
+		'https://api.github.com/repos/guardian/repo-name/comments{/number}',
+	commits_url: 'https://api.github.com/repos/guardian/repo-name/commits{/sha}',
+	compare_url:
+		'https://api.github.com/repos/guardian/repo-name/compare/{base}...{head}',
+	contents_url:
+		'https://api.github.com/repos/guardian/repo-name/contents/{+path}',
+	contributors_url:
+		'https://api.github.com/repos/guardian/repo-name/contributors',
+	deployments_url:
+		'https://api.github.com/repos/guardian/repo-name/deployments',
+	downloads_url: 'https://api.github.com/repos/guardian/repo-name/downloads',
+	events_url: 'https://api.github.com/repos/guardian/repo-name/events',
+	forks_url: 'https://api.github.com/repos/guardian/repo-name/forks',
+	git_commits_url:
+		'https://api.github.com/repos/guardian/repo-name/git/commits{/sha}',
+	git_refs_url:
+		'https://api.github.com/repos/guardian/repo-name/git/refs{/sha}',
+	git_tags_url:
+		'https://api.github.com/repos/guardian/repo-name/git/tags{/sha}',
+	git_url: 'git:github.com/guardian/repo-name.git',
+	issue_comment_url:
+		'https://api.github.com/repos/guardian/repo-name/issues/comments{/number}',
+	issue_events_url:
+		'https://api.github.com/repos/guardian/repo-name/issues/events{/number}',
+	issues_url: 'https://api.github.com/repos/guardian/repo-name/issues{/number}',
+	keys_url: 'https://api.github.com/repos/guardian/repo-name/keys{/key_id}',
+	labels_url: 'https://api.github.com/repos/guardian/repo-name/labels{/name}',
+	languages_url: 'https://api.github.com/repos/guardian/repo-name/languages',
+	merges_url: 'https://api.github.com/repos/guardian/repo-name/merges',
+	milestones_url:
+		'https://api.github.com/repos/guardian/repo-name/milestones{/number}',
+	notifications_url:
+		'https://api.github.com/repos/guardian/repo-name/notifications{?since,all,participating}',
+	pulls_url: 'https://api.github.com/repos/guardian/repo-name/pulls{/number}',
+	releases_url: 'https://api.github.com/repos/guardian/repo-name/releases{/id}',
+	ssh_url: 'git@github.com:guardian/repo-name.git',
+	stargazers_url: 'https://api.github.com/repos/guardian/repo-name/stargazers',
+	statuses_url:
+		'https://api.github.com/repos/guardian/repo-name/statuses/{sha}',
+	subscribers_url:
+		'https://api.github.com/repos/guardian/repo-name/subscribers',
+	subscription_url:
+		'https://api.github.com/repos/guardian/repo-name/subscription',
+	tags_url: 'https://api.github.com/repos/guardian/repo-name/tags',
+	teams_url: 'https://api.github.com/repos/guardian/repo-name/teams',
+	trees_url: 'https://api.github.com/repos/guardian/repo-name/git/trees{/sha}',
+	clone_url: 'https://github.com/guardian/repo-name.git',
+	mirror_url: 'git:git.example.com/guardian/repo-name',
+	hooks_url: 'https://api.github.com/repos/guardian/repo-name/hooks',
+	svn_url: 'https://svn.github.com/guardian/repo-name',
+	homepage: 'https://github.com',
+	language: null,
+	forks_count: 9,
+	stargazers_count: 80,
+	watchers_count: 80,
+	size: 108,
+	default_branch: 'master',
+	open_issues_count: 0,
+	is_template: false,
+	topics: ['production'],
+	has_issues: true,
+	has_projects: true,
+	has_wiki: true,
+	has_pages: false,
+	has_downloads: true,
+	archived: false,
+	disabled: false,
+	visibility: 'public',
+	pushed_at: '2011-01-26T19:06:43Z',
+	created_at: '2011-01-26T19:01:12Z',
+	updated_at: '2011-01-26T19:14:43Z',
+	permissions: {
+		admin: false,
+		push: false,
+		pull: true,
+	},
+	template_repository: null,
+};

--- a/packages/repo-fetcher/src/transformations.test.ts
+++ b/packages/repo-fetcher/src/transformations.test.ts
@@ -1,3 +1,5 @@
+import type { RepositoryResponse } from '../../common/github/github';
+import { mockRepo } from './mockRepo';
 import type { Repository } from './transformations';
 import {
 	findOwnersOfRepo,
@@ -22,140 +24,8 @@ describe('repository owners', function () {
 
 describe('repository objects', function () {
 	it('should combine a RepositoryResponse with a list of owners', function () {
-		const repo = {
-			id: 123456,
-			node_id: 'MDEwOlJlcG9zaXRvcnkxMjk2MjY5',
-			name: 'repo-name',
-			full_name: 'guardian/repo-name',
-			owner: {
-				login: 'guardian',
-				id: 1,
-				node_id: 'MDQ6VXNlcjE=',
-				avatar_url: 'https://github.com/images/error/octocat_happy.gif',
-				gravatar_id: '',
-				url: 'https://api.github.com/users/octocat',
-				html_url: 'https://github.com/octocat',
-				followers_url: 'https://api.github.com/users/octocat/followers',
-				following_url:
-					'https://api.github.com/users/octocat/following{/other_user}',
-				gists_url: 'https://api.github.com/users/octocat/gists{/gist_id}',
-				starred_url:
-					'https://api.github.com/users/octocat/starred{/owner}{/repo}',
-				subscriptions_url: 'https://api.github.com/users/octocat/subscriptions',
-				organizations_url: 'https://api.github.com/users/octocat/orgs',
-				repos_url: 'https://api.github.com/users/octocat/repos',
-				events_url: 'https://api.github.com/users/octocat/events{/privacy}',
-				received_events_url:
-					'https://api.github.com/users/octocat/received_events',
-				type: 'User',
-				site_admin: false,
-			},
-			private: false,
-			html_url: 'https://github.com/guardian/repo-name',
-			description: 'This your first repo!',
-			fork: false,
-			url: 'https://api.github.com/repos/guardian/repo-name',
-			archive_url:
-				'https://api.github.com/repos/guardian/repo-name/{archive_format}{/ref}',
-			assignees_url:
-				'https://api.github.com/repos/guardian/repo-name/assignees{/user}',
-			blobs_url:
-				'https://api.github.com/repos/guardian/repo-name/git/blobs{/sha}',
-			branches_url:
-				'https://api.github.com/repos/guardian/repo-name/branches{/branch}',
-			collaborators_url:
-				'https://api.github.com/repos/guardian/repo-name/collaborators{/collaborator}',
-			comments_url:
-				'https://api.github.com/repos/guardian/repo-name/comments{/number}',
-			commits_url:
-				'https://api.github.com/repos/guardian/repo-name/commits{/sha}',
-			compare_url:
-				'https://api.github.com/repos/guardian/repo-name/compare/{base}...{head}',
-			contents_url:
-				'https://api.github.com/repos/guardian/repo-name/contents/{+path}',
-			contributors_url:
-				'https://api.github.com/repos/guardian/repo-name/contributors',
-			deployments_url:
-				'https://api.github.com/repos/guardian/repo-name/deployments',
-			downloads_url:
-				'https://api.github.com/repos/guardian/repo-name/downloads',
-			events_url: 'https://api.github.com/repos/guardian/repo-name/events',
-			forks_url: 'https://api.github.com/repos/guardian/repo-name/forks',
-			git_commits_url:
-				'https://api.github.com/repos/guardian/repo-name/git/commits{/sha}',
-			git_refs_url:
-				'https://api.github.com/repos/guardian/repo-name/git/refs{/sha}',
-			git_tags_url:
-				'https://api.github.com/repos/guardian/repo-name/git/tags{/sha}',
-			git_url: 'git:github.com/guardian/repo-name.git',
-			issue_comment_url:
-				'https://api.github.com/repos/guardian/repo-name/issues/comments{/number}',
-			issue_events_url:
-				'https://api.github.com/repos/guardian/repo-name/issues/events{/number}',
-			issues_url:
-				'https://api.github.com/repos/guardian/repo-name/issues{/number}',
-			keys_url: 'https://api.github.com/repos/guardian/repo-name/keys{/key_id}',
-			labels_url:
-				'https://api.github.com/repos/guardian/repo-name/labels{/name}',
-			languages_url:
-				'https://api.github.com/repos/guardian/repo-name/languages',
-			merges_url: 'https://api.github.com/repos/guardian/repo-name/merges',
-			milestones_url:
-				'https://api.github.com/repos/guardian/repo-name/milestones{/number}',
-			notifications_url:
-				'https://api.github.com/repos/guardian/repo-name/notifications{?since,all,participating}',
-			pulls_url:
-				'https://api.github.com/repos/guardian/repo-name/pulls{/number}',
-			releases_url:
-				'https://api.github.com/repos/guardian/repo-name/releases{/id}',
-			ssh_url: 'git@github.com:guardian/repo-name.git',
-			stargazers_url:
-				'https://api.github.com/repos/guardian/repo-name/stargazers',
-			statuses_url:
-				'https://api.github.com/repos/guardian/repo-name/statuses/{sha}',
-			subscribers_url:
-				'https://api.github.com/repos/guardian/repo-name/subscribers',
-			subscription_url:
-				'https://api.github.com/repos/guardian/repo-name/subscription',
-			tags_url: 'https://api.github.com/repos/guardian/repo-name/tags',
-			teams_url: 'https://api.github.com/repos/guardian/repo-name/teams',
-			trees_url:
-				'https://api.github.com/repos/guardian/repo-name/git/trees{/sha}',
-			clone_url: 'https://github.com/guardian/repo-name.git',
-			mirror_url: 'git:git.example.com/guardian/repo-name',
-			hooks_url: 'https://api.github.com/repos/guardian/repo-name/hooks',
-			svn_url: 'https://svn.github.com/guardian/repo-name',
-			homepage: 'https://github.com',
-			language: null,
-			forks_count: 9,
-			stargazers_count: 80,
-			watchers_count: 80,
-			size: 108,
-			default_branch: 'master',
-			open_issues_count: 0,
-			is_template: false,
-			topics: ['production'],
-			has_issues: true,
-			has_projects: true,
-			has_wiki: true,
-			has_pages: false,
-			has_downloads: true,
-			archived: false,
-			disabled: false,
-			visibility: 'public',
-			pushed_at: '2011-01-26T19:06:43Z',
-			created_at: '2011-01-26T19:01:12Z',
-			updated_at: '2011-01-26T19:14:43Z',
-			permissions: {
-				admin: false,
-				push: false,
-				pull: true,
-			},
-			template_repository: null,
-		};
-
 		const owners = ['team3', 'team4'];
-
+		const repo: RepositoryResponse = mockRepo;
 		const finalRepoObject: Repository = transformRepo(repo, owners);
 
 		expect(finalRepoObject.owners).toStrictEqual(['team3', 'team4']);

--- a/packages/repo-fetcher/src/transformations.test.ts
+++ b/packages/repo-fetcher/src/transformations.test.ts
@@ -1,0 +1,135 @@
+import {findOwnersOfRepo, RepoAndOwner} from "./transformations";
+import {RepositoryResponse} from "../../common/github/github"
+import { transformRepo, Repository } from "./handler";
+
+describe('repository owners', function () {
+    it('should not be returned if none exist for that repo', function () {
+        
+
+        expect(findOwnersOfRepo("someRepo", [])).toStrictEqual([])
+    });
+    it('should be returned only if they exist for that specific repo', function () {
+        const owner1 = new RepoAndOwner("team1", "someRepo")
+        const owner2 = new RepoAndOwner("team2", "someRepo")
+        const owner3 = new RepoAndOwner("team3", "aDifferentRepo")
+
+        const ownerArray = findOwnersOfRepo("someRepo", [owner1, owner2, owner3])
+
+        expect(ownerArray).toStrictEqual(["team1", "team2"])
+    });
+});
+
+
+describe('repository objects', function () {
+    it('should combine a RepositoryResponse with a list of owners', function () {
+
+        const repo = {
+            "id": 123456,
+            "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
+            "name": "repo-name",
+            "full_name": "guardian/repo-name",
+            "owner": {
+              "login": "guardian",
+              "id": 1,
+              "node_id": "MDQ6VXNlcjE=",
+              "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/octocat",
+              "html_url": "https://github.com/octocat",
+              "followers_url": "https://api.github.com/users/octocat/followers",
+              "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+              "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+              "organizations_url": "https://api.github.com/users/octocat/orgs",
+              "repos_url": "https://api.github.com/users/octocat/repos",
+              "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/octocat/received_events",
+              "type": "User",
+              "site_admin": false
+            },
+            "private": false,
+            "html_url": "https://github.com/guardian/repo-name",
+            "description": "This your first repo!",
+            "fork": false,
+            "url": "https://api.github.com/repos/guardian/repo-name",
+            "archive_url": "https://api.github.com/repos/guardian/repo-name/{archive_format}{/ref}",
+            "assignees_url": "https://api.github.com/repos/guardian/repo-name/assignees{/user}",
+            "blobs_url": "https://api.github.com/repos/guardian/repo-name/git/blobs{/sha}",
+            "branches_url": "https://api.github.com/repos/guardian/repo-name/branches{/branch}",
+            "collaborators_url": "https://api.github.com/repos/guardian/repo-name/collaborators{/collaborator}",
+            "comments_url": "https://api.github.com/repos/guardian/repo-name/comments{/number}",
+            "commits_url": "https://api.github.com/repos/guardian/repo-name/commits{/sha}",
+            "compare_url": "https://api.github.com/repos/guardian/repo-name/compare/{base}...{head}",
+            "contents_url": "https://api.github.com/repos/guardian/repo-name/contents/{+path}",
+            "contributors_url": "https://api.github.com/repos/guardian/repo-name/contributors",
+            "deployments_url": "https://api.github.com/repos/guardian/repo-name/deployments",
+            "downloads_url": "https://api.github.com/repos/guardian/repo-name/downloads",
+            "events_url": "https://api.github.com/repos/guardian/repo-name/events",
+            "forks_url": "https://api.github.com/repos/guardian/repo-name/forks",
+            "git_commits_url": "https://api.github.com/repos/guardian/repo-name/git/commits{/sha}",
+            "git_refs_url": "https://api.github.com/repos/guardian/repo-name/git/refs{/sha}",
+            "git_tags_url": "https://api.github.com/repos/guardian/repo-name/git/tags{/sha}",
+            "git_url": "git:github.com/guardian/repo-name.git",
+            "issue_comment_url": "https://api.github.com/repos/guardian/repo-name/issues/comments{/number}",
+            "issue_events_url": "https://api.github.com/repos/guardian/repo-name/issues/events{/number}",
+            "issues_url": "https://api.github.com/repos/guardian/repo-name/issues{/number}",
+            "keys_url": "https://api.github.com/repos/guardian/repo-name/keys{/key_id}",
+            "labels_url": "https://api.github.com/repos/guardian/repo-name/labels{/name}",
+            "languages_url": "https://api.github.com/repos/guardian/repo-name/languages",
+            "merges_url": "https://api.github.com/repos/guardian/repo-name/merges",
+            "milestones_url": "https://api.github.com/repos/guardian/repo-name/milestones{/number}",
+            "notifications_url": "https://api.github.com/repos/guardian/repo-name/notifications{?since,all,participating}",
+            "pulls_url": "https://api.github.com/repos/guardian/repo-name/pulls{/number}",
+            "releases_url": "https://api.github.com/repos/guardian/repo-name/releases{/id}",
+            "ssh_url": "git@github.com:guardian/repo-name.git",
+            "stargazers_url": "https://api.github.com/repos/guardian/repo-name/stargazers",
+            "statuses_url": "https://api.github.com/repos/guardian/repo-name/statuses/{sha}",
+            "subscribers_url": "https://api.github.com/repos/guardian/repo-name/subscribers",
+            "subscription_url": "https://api.github.com/repos/guardian/repo-name/subscription",
+            "tags_url": "https://api.github.com/repos/guardian/repo-name/tags",
+            "teams_url": "https://api.github.com/repos/guardian/repo-name/teams",
+            "trees_url": "https://api.github.com/repos/guardian/repo-name/git/trees{/sha}",
+            "clone_url": "https://github.com/guardian/repo-name.git",
+            "mirror_url": "git:git.example.com/guardian/repo-name",
+            "hooks_url": "https://api.github.com/repos/guardian/repo-name/hooks",
+            "svn_url": "https://svn.github.com/guardian/repo-name",
+            "homepage": "https://github.com",
+            "language": null,
+            "forks_count": 9,
+            "stargazers_count": 80,
+            "watchers_count": 80,
+            "size": 108,
+            "default_branch": "master",
+            "open_issues_count": 0,
+            "is_template": false,
+            "topics": [
+              "production"
+            ],
+            "has_issues": true,
+            "has_projects": true,
+            "has_wiki": true,
+            "has_pages": false,
+            "has_downloads": true,
+            "archived": false,
+            "disabled": false,
+            "visibility": "public",
+            "pushed_at": "2011-01-26T19:06:43Z",
+            "created_at": "2011-01-26T19:01:12Z",
+            "updated_at": "2011-01-26T19:14:43Z",
+            "permissions": {
+              "admin": false,
+              "push": false,
+              "pull": true
+            },
+            "template_repository": null
+          }
+
+        const owners = ["team3", "team4"];
+
+        const finalRepoObject: Repository = transformRepo(repo,owners)
+
+        expect(finalRepoObject.owners).toStrictEqual(["team3", "team4"])
+        expect(finalRepoObject.name).toStrictEqual("repo-name")
+    });
+});

--- a/packages/repo-fetcher/src/transformations.test.ts
+++ b/packages/repo-fetcher/src/transformations.test.ts
@@ -1,7 +1,9 @@
-import { RepositoryResponse } from '../../common/github/github';
-import type { Repository } from './handler';
-import { transformRepo } from './handler';
-import { findOwnersOfRepo, RepoAndOwner } from './transformations';
+import type { Repository } from './transformations';
+import {
+	findOwnersOfRepo,
+	RepoAndOwner,
+	transformRepo,
+} from './transformations';
 
 describe('repository owners', function () {
 	it('should not be returned if none exist for that repo', function () {

--- a/packages/repo-fetcher/src/transformations.ts
+++ b/packages/repo-fetcher/src/transformations.ts
@@ -1,5 +1,3 @@
-import type { Config } from '../../common/config';
-import { getReposForTeam } from '../../common/github/github';
 import type {
 	RepositoryResponse,
 	TeamRepoResponse,
@@ -76,15 +74,6 @@ export const getAdminReposFromResponse = (
 	return repos
 		.filter((repo) => repo.role_name === 'admin')
 		.map((repo) => repo.name);
-};
-
-export const createOwnerObjects = async (
-	config: Config,
-	teamSlug: string,
-): Promise<RepoAndOwner[]> => {
-	const allRepos: TeamRepoResponse = await getReposForTeam(config, teamSlug);
-	const adminRepos: string[] = getAdminReposFromResponse(allRepos);
-	return adminRepos.map((repoName) => new RepoAndOwner(teamSlug, repoName));
 };
 
 export const findOwnersOfRepo = (

--- a/packages/repo-fetcher/src/transformations.ts
+++ b/packages/repo-fetcher/src/transformations.ts
@@ -23,5 +23,5 @@ export const createOwnerObjects = async (config: Config, teamSlug: string): Prom
 export const findOwnersOfRepo = (repoName: string, ownerObjects: RepoAndOwner[]): string[] => {
     return ownerObjects
         .filter(repoAndOwner => repoAndOwner.repoName == repoName)
-        .map(repoAndOwner => repoAndOwner.repoName)
+        .map(repoAndOwner => repoAndOwner.teamSlug)
 }

--- a/packages/repo-fetcher/src/transformations.ts
+++ b/packages/repo-fetcher/src/transformations.ts
@@ -1,0 +1,27 @@
+import { getReposForTeam, TeamRepoResponse } from "../../common/github/github";
+import { Config } from "../../common/config";
+
+export class RepoAndOwner {
+    teamSlug: string;
+    repoName: string
+    constructor(teamSlug: string, repoName: string) {
+        this.teamSlug = teamSlug
+        this.repoName = repoName
+    }
+}
+
+export const getAdminReposFromResponse = (repos: TeamRepoResponse): string[] => {
+    return repos.filter(repo => repo.role_name === "admin").map(repo => repo.name);
+}
+
+export const createOwnerObjects = async (config: Config, teamSlug: string): Promise<RepoAndOwner[]> => {
+    const allRepos: TeamRepoResponse = await getReposForTeam(config, teamSlug);
+    const adminRepos: string[] = getAdminReposFromResponse(allRepos);
+    return adminRepos.map(repoName => new RepoAndOwner(teamSlug, repoName))
+}
+
+export const findOwnersOfRepo = (repoName: string, ownerObjects: RepoAndOwner[]): string[] => {
+    return ownerObjects
+        .filter(repoAndOwner => repoAndOwner.repoName == repoName)
+        .map(repoAndOwner => repoAndOwner.repoName)
+}

--- a/packages/repo-fetcher/src/transformations.ts
+++ b/packages/repo-fetcher/src/transformations.ts
@@ -1,6 +1,65 @@
 import type { Config } from '../../common/config';
-import type { TeamRepoResponse } from '../../common/github/github';
 import { getReposForTeam } from '../../common/github/github';
+import type {
+	RepositoryResponse,
+	TeamRepoResponse,
+} from '../../common/github/github';
+
+export interface Repository {
+	id: number;
+	name: string;
+	full_name: string;
+	private: boolean;
+	description: string | null;
+	created_at: Date | null;
+	updated_at: Date | null;
+	pushed_at: Date | null;
+	size: number | undefined;
+	language: string | null | undefined;
+	archived: boolean | undefined;
+	open_issues_count: number | undefined;
+	is_template: boolean | undefined;
+	topics: string[] | undefined;
+	default_branch: string | undefined;
+	owners: string[];
+}
+
+const parseDateString = (
+	dateString: string | null | undefined,
+): Date | null => {
+	if (
+		dateString === undefined ||
+		dateString === null ||
+		dateString.length === 0
+	) {
+		return null;
+	}
+	return new Date(dateString);
+};
+
+export const transformRepo = (
+	repo: RepositoryResponse,
+	owners: string[],
+): Repository => {
+	return {
+		id: repo.id,
+		name: repo.name,
+		full_name: repo.full_name,
+		private: repo.private,
+		description: repo.description,
+		created_at: parseDateString(repo.created_at),
+		updated_at: parseDateString(repo.updated_at),
+		pushed_at: parseDateString(repo.pushed_at),
+		size: repo.size,
+		language: repo.language,
+		archived: repo.archived,
+		open_issues_count: repo.open_issues_count,
+		is_template: repo.is_template,
+		topics: repo.topics,
+		default_branch: repo.default_branch,
+		owners: owners,
+	};
+};
 
 export class RepoAndOwner {
 	teamSlug: string;


### PR DESCRIPTION
## What does this change?

Apart from linting, this change introduces a a way to include repository team owners as part of the Repo object 

## How to test

`npm run test -w packages/repo-fetcher`

Verify that all tests pass

## Have we considered potential risks?

We have skirted round any potential API limits but requesting owners per team, rather than by repo. There are ~100 teams and ~3000 repos at time of writing, so even paginated, this is a 30x reduction in pages requested.