### PR TITLE
Setup jest in order that tests in common package run

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,17 +1,18 @@
-const generateProject = name => {
-  return {
-    displayName: name,
-    transform: {
-      '^.+\\.tsx?$': 'ts-jest',
-    },
-    testMatch: [`<rootDir>/packages/${name}/**/*.test.ts`],
-    setupFilesAfterEnv: [`./packages/${name}/jest.setup.js`],
-  }
-}
-
-module.exports = {
-  verbose: true,
-  testEnvironment: 'node',
-  projects: ['cdk', 'api', 'repo-fetcher', 'teams-fetcher'].map(generateProject)
+const generateProject = (name) => {
+	return {
+		displayName: name,
+		transform: {
+			'^.+\\.tsx?$': 'ts-jest',
+		},
+		testMatch: [`<rootDir>/packages/${name}/**/*.test.ts`],
+		setupFilesAfterEnv: [`./packages/${name}/jest.setup.js`],
+	};
 };
 
+module.exports = {
+	verbose: true,
+	testEnvironment: 'node',
+	projects: ['cdk', 'api', 'repo-fetcher', 'teams-fetcher', 'common'].map(
+		generateProject,
+	),
+};


### PR DESCRIPTION
## What does this change?

This change adds `common` to the list of packages that need to be tested by jest (currently some tests in that folder are being missed).

## How to test

Ensure tests in `common` package are being run by GHA: [They do!](https://github.com/guardian/github-lens/actions/runs/3097544067/jobs/5014340517#step:5:61)