### PR TITLE
chore: Remove empty teams-fetcher project

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,7 @@ const generateProject = (name) => {
 module.exports = {
 	verbose: true,
 	testEnvironment: 'node',
-	projects: ['cdk', 'api', 'repo-fetcher', 'teams-fetcher', 'common'].map(
+	projects: ['cdk', 'api', 'repo-fetcher', 'common'].map(
 		generateProject,
 	),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9369,11 +9369,6 @@
       "devDependencies": {
         "esbuild": "^0.14.53"
       }
-    },
-    "packages/teams-fetcher": {
-      "name": "github-lens-teams-fetcher",
-      "version": "0.0.1",
-      "extraneous": true
     }
   },
   "dependencies": {

--- a/packages/teams-fetcher/package.json
+++ b/packages/teams-fetcher/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "teams-fetcher",
-  "version": "0.0.1",
-  "description": "A fetcher for teams metadata from your GitHub organisation",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "typecheck": "tsc -noEmit"
-  }
-}


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

It looks like this project has evolved into [repo-fetcher](https://github.com/guardian/github-lens/tree/main/packages/repo-fetcher). Remove it to avoid confusion.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

N/A
