### PR TITLE
Jb/facilitate development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist
 /.vscode/settings.json
 .eslintcache
 .env
+test/*.json
+test/localJsonFilesCreated

--- a/README.md
+++ b/README.md
@@ -24,9 +24,16 @@ The setup script will download a starter `.env`.
 
 ### Running locally
 
-The project uses npm workspaces, and individual workspaces should have a `dev` script that can be run to execute e.g.
+The project uses npm workspaces, and individual workspaces should have a `dev` script that can be run to execute 
+
+To fetch the data you need to run
 ```
 npm -w packages/repo-fetcher run dev
+```
+
+This will start the api on localhost:3232
+```
+npm -w packages/github-lens-api run dev
 ```
 
 ### Testing

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.190.0",
         "@types/jest": "^28.1.6",
         "@types/node": "^18.6.3",
         "dotenv": "^16.0.1",
@@ -38,7 +39,8 @@
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "2.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
+      "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
       "dependencies": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -47,7 +49,8 @@
     },
     "node_modules/@aws-crypto/crc32c": {
       "version": "2.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
+      "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
       "dependencies": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -128,27 +131,39 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/chunked-blob-reader": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
+      "integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
       "dependencies": {
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.188.0.tgz",
+      "integrity": "sha512-WielYjaAHfT/HAOW7Tj6yVeNdaOtts3aUm9Sf/3D+ElbCTGyaaMNfE4x0a+qn6dJZXewf1eAxybOIU5ftIeSGw==",
       "dependencies": {
-        "@aws-sdk/util-base64-browser": "3.168.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/chunked-blob-reader-native/node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
+      "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
+      "dependencies": {
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/chunked-blob-reader-native/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/chunked-blob-reader/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/client-kms": {
       "version": "3.169.0",
@@ -198,71 +213,816 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.169.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.190.0.tgz",
+      "integrity": "sha512-ngF92/X+odFt5Zbs5AWTozI+35fwFkHghbDABi5uSWNtgs2alSc/A94/yexbDdvVrVnuUa/FAMkvYX8duGZ9ig==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.169.0",
-        "@aws-sdk/config-resolver": "3.168.0",
-        "@aws-sdk/credential-provider-node": "3.169.0",
-        "@aws-sdk/eventstream-serde-browser": "3.168.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.168.0",
-        "@aws-sdk/eventstream-serde-node": "3.168.0",
-        "@aws-sdk/fetch-http-handler": "3.168.0",
-        "@aws-sdk/hash-blob-browser": "3.168.0",
-        "@aws-sdk/hash-node": "3.168.0",
-        "@aws-sdk/hash-stream-node": "3.168.0",
-        "@aws-sdk/invalid-dependency": "3.168.0",
-        "@aws-sdk/md5-js": "3.168.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.168.0",
-        "@aws-sdk/middleware-content-length": "3.168.0",
-        "@aws-sdk/middleware-expect-continue": "3.168.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.168.0",
-        "@aws-sdk/middleware-host-header": "3.168.0",
-        "@aws-sdk/middleware-location-constraint": "3.168.0",
-        "@aws-sdk/middleware-logger": "3.168.0",
-        "@aws-sdk/middleware-recursion-detection": "3.168.0",
-        "@aws-sdk/middleware-retry": "3.169.0",
-        "@aws-sdk/middleware-sdk-s3": "3.168.0",
-        "@aws-sdk/middleware-serde": "3.168.0",
-        "@aws-sdk/middleware-signing": "3.168.0",
-        "@aws-sdk/middleware-ssec": "3.168.0",
-        "@aws-sdk/middleware-stack": "3.168.0",
-        "@aws-sdk/middleware-user-agent": "3.168.0",
-        "@aws-sdk/node-config-provider": "3.168.0",
-        "@aws-sdk/node-http-handler": "3.168.0",
-        "@aws-sdk/protocol-http": "3.168.0",
-        "@aws-sdk/signature-v4-multi-region": "3.168.0",
-        "@aws-sdk/smithy-client": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
-        "@aws-sdk/url-parser": "3.168.0",
-        "@aws-sdk/util-base64-browser": "3.168.0",
-        "@aws-sdk/util-base64-node": "3.168.0",
-        "@aws-sdk/util-body-length-browser": "3.168.0",
-        "@aws-sdk/util-body-length-node": "3.168.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.168.0",
-        "@aws-sdk/util-defaults-mode-node": "3.168.0",
-        "@aws-sdk/util-stream-browser": "3.168.0",
-        "@aws-sdk/util-stream-node": "3.168.0",
-        "@aws-sdk/util-user-agent-browser": "3.168.0",
-        "@aws-sdk/util-user-agent-node": "3.168.0",
-        "@aws-sdk/util-utf8-browser": "3.168.0",
-        "@aws-sdk/util-utf8-node": "3.168.0",
-        "@aws-sdk/util-waiter": "3.168.0",
-        "@aws-sdk/xml-builder": "3.168.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
+        "@aws-sdk/client-sts": "3.190.0",
+        "@aws-sdk/config-resolver": "3.190.0",
+        "@aws-sdk/credential-provider-node": "3.190.0",
+        "@aws-sdk/eventstream-serde-browser": "3.190.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.190.0",
+        "@aws-sdk/eventstream-serde-node": "3.190.0",
+        "@aws-sdk/fetch-http-handler": "3.190.0",
+        "@aws-sdk/hash-blob-browser": "3.190.0",
+        "@aws-sdk/hash-node": "3.190.0",
+        "@aws-sdk/hash-stream-node": "3.190.0",
+        "@aws-sdk/invalid-dependency": "3.190.0",
+        "@aws-sdk/md5-js": "3.190.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.190.0",
+        "@aws-sdk/middleware-content-length": "3.190.0",
+        "@aws-sdk/middleware-expect-continue": "3.190.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.190.0",
+        "@aws-sdk/middleware-host-header": "3.190.0",
+        "@aws-sdk/middleware-location-constraint": "3.190.0",
+        "@aws-sdk/middleware-logger": "3.190.0",
+        "@aws-sdk/middleware-recursion-detection": "3.190.0",
+        "@aws-sdk/middleware-retry": "3.190.0",
+        "@aws-sdk/middleware-sdk-s3": "3.190.0",
+        "@aws-sdk/middleware-serde": "3.190.0",
+        "@aws-sdk/middleware-signing": "3.190.0",
+        "@aws-sdk/middleware-ssec": "3.190.0",
+        "@aws-sdk/middleware-stack": "3.190.0",
+        "@aws-sdk/middleware-user-agent": "3.190.0",
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/node-http-handler": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/signature-v4-multi-region": "3.190.0",
+        "@aws-sdk/smithy-client": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/url-parser": "3.190.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.188.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.190.0",
+        "@aws-sdk/util-defaults-mode-node": "3.190.0",
+        "@aws-sdk/util-stream-browser": "3.190.0",
+        "@aws-sdk/util-stream-node": "3.190.0",
+        "@aws-sdk/util-user-agent-browser": "3.190.0",
+        "@aws-sdk/util-user-agent-node": "3.190.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.188.0",
+        "@aws-sdk/util-waiter": "3.190.0",
+        "@aws-sdk/xml-builder": "3.188.0",
+        "fast-xml-parser": "4.0.11",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.190.0.tgz",
+      "integrity": "sha512-M6qo2exTzEfHT5RuW7K090OgesUojhb2JyWiV4ulu7ngY4DWBUBMKUqac696sHRUZvGE5CDzSi0606DMboM+kA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.190.0.tgz",
+      "integrity": "sha512-joEKRjJEzgvXnEih/x2UDDCPlvXWCO3MAHmqi44yJ36Ph4YsFS299mOjPdVLuzUtpQ+cST1nRO7hXNFrulW2jQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.190.0",
+        "@aws-sdk/fetch-http-handler": "3.190.0",
+        "@aws-sdk/hash-node": "3.190.0",
+        "@aws-sdk/invalid-dependency": "3.190.0",
+        "@aws-sdk/middleware-content-length": "3.190.0",
+        "@aws-sdk/middleware-host-header": "3.190.0",
+        "@aws-sdk/middleware-logger": "3.190.0",
+        "@aws-sdk/middleware-recursion-detection": "3.190.0",
+        "@aws-sdk/middleware-retry": "3.190.0",
+        "@aws-sdk/middleware-serde": "3.190.0",
+        "@aws-sdk/middleware-stack": "3.190.0",
+        "@aws-sdk/middleware-user-agent": "3.190.0",
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/node-http-handler": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/smithy-client": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/url-parser": "3.190.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.188.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.190.0",
+        "@aws-sdk/util-defaults-mode-node": "3.190.0",
+        "@aws-sdk/util-user-agent-browser": "3.190.0",
+        "@aws-sdk/util-user-agent-node": "3.190.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.190.0.tgz",
+      "integrity": "sha512-s5MqfxqWxHAl1RhfQ6swjawsVPBqmq5F+SfzZcGLBCnVv03GaSL8J9K42O1Cc0+HwPQH2miY+Avy0zAr6VpY+Q==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.190.0",
+        "@aws-sdk/credential-provider-node": "3.190.0",
+        "@aws-sdk/fetch-http-handler": "3.190.0",
+        "@aws-sdk/hash-node": "3.190.0",
+        "@aws-sdk/invalid-dependency": "3.190.0",
+        "@aws-sdk/middleware-content-length": "3.190.0",
+        "@aws-sdk/middleware-host-header": "3.190.0",
+        "@aws-sdk/middleware-logger": "3.190.0",
+        "@aws-sdk/middleware-recursion-detection": "3.190.0",
+        "@aws-sdk/middleware-retry": "3.190.0",
+        "@aws-sdk/middleware-sdk-sts": "3.190.0",
+        "@aws-sdk/middleware-serde": "3.190.0",
+        "@aws-sdk/middleware-signing": "3.190.0",
+        "@aws-sdk/middleware-stack": "3.190.0",
+        "@aws-sdk/middleware-user-agent": "3.190.0",
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/node-http-handler": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/smithy-client": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/url-parser": "3.190.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.188.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.190.0",
+        "@aws-sdk/util-defaults-mode-node": "3.190.0",
+        "@aws-sdk/util-user-agent-browser": "3.190.0",
+        "@aws-sdk/util-user-agent-node": "3.190.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.188.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.190.0.tgz",
+      "integrity": "sha512-K+VnDtjTgjpf7yHEdDB0qgGbHToF0pIL0pQMSnmk2yc8BoB3LGG/gg1T0Ki+wRlrFnDCJ6L+8zUdawY2qDsbyw==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-config-provider": "3.188.0",
+        "@aws-sdk/util-middleware": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.190.0.tgz",
+      "integrity": "sha512-GTY7l3SJhTmRGFpWddbdJOihSqoMN8JMo3CsCtIjk4/h3xirBi02T4GSvbrMyP7FP3Fdl4NAdT+mHJ4q2Bvzxw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.190.0.tgz",
+      "integrity": "sha512-gI5pfBqGYCKdmx8igPvq+jLzyE2kuNn9Q5u73pdM/JZxiq7GeWYpE/MqqCubHxPtPcTFgAwxCxCFoXlUTBh/2g==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/url-parser": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.190.0.tgz",
+      "integrity": "sha512-Z7NN/evXJk59hBQlfOSWDfHntwmxwryu6uclgv7ECI6SEVtKt1EKIlPuCLUYgQ4lxb9bomyO5lQAl/1WutNT5w==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.190.0",
+        "@aws-sdk/credential-provider-imds": "3.190.0",
+        "@aws-sdk/credential-provider-sso": "3.190.0",
+        "@aws-sdk/credential-provider-web-identity": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/shared-ini-file-loader": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.190.0.tgz",
+      "integrity": "sha512-ctCG5+TsIK2gVgvvFiFjinPjc5nGpSypU3nQKCaihtPh83wDN6gCx4D0p9M8+fUrlPa5y+o/Y7yHo94ATepM8w==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.190.0",
+        "@aws-sdk/credential-provider-imds": "3.190.0",
+        "@aws-sdk/credential-provider-ini": "3.190.0",
+        "@aws-sdk/credential-provider-process": "3.190.0",
+        "@aws-sdk/credential-provider-sso": "3.190.0",
+        "@aws-sdk/credential-provider-web-identity": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/shared-ini-file-loader": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.190.0.tgz",
+      "integrity": "sha512-sIJhICR80n5XY1kW/EFHTh5ZzBHb5X+744QCH3StcbKYI44mOZvNKfFdeRL2fQ7yLgV7npte2HJRZzQPWpZUrw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/shared-ini-file-loader": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.190.0.tgz",
+      "integrity": "sha512-uarU9vk471MHHT+GJj3KWFSmaaqLNL5n1KcMer2CCAZfjs+mStAi8+IjZuuKXB4vqVs5DxdH8cy5aLaJcBlXwQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/shared-ini-file-loader": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.190.0.tgz",
+      "integrity": "sha512-nlIBeK9hGHKWC874h+ITAfPZ9Eaok+x/ydZQVKsLHiQ9PH3tuQ8AaGqhuCwBSH0hEAHZ/BiKeEx5VyWAE8/x+Q==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.190.0.tgz",
+      "integrity": "sha512-5riRpKydARXAPLesTZm6eP6QKJ4HJGQ3k0Tepi3nvxHVx3UddkRNoX0pLS3rvbajkykWPNC2qdfRGApWlwOYsA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/querystring-builder": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/hash-node": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.190.0.tgz",
+      "integrity": "sha512-DNwVT3O8zc9Jk/bXiXcN0WsD98r+JJWryw9F1/ZZbuzbf6rx2qhI8ZK+nh5X6WMtYPU84luQMcF702fJt/1bzg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-buffer-from": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.190.0.tgz",
+      "integrity": "sha512-crCh63e8d/Uw9y3dQlVTPja7+IZiXpNXyH6oSuAadTDQwMq6KK87Av1/SDzVf6bAo2KgAOo41MyO2joaCEk0dQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
+      "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.190.0.tgz",
+      "integrity": "sha512-sSU347SuC6I8kWum1jlJlpAqeV23KP7enG+ToWcEcgFrJhm3AvuqB//NJxDbkKb2DNroRvJjBckBvrwNAjQnBQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.190.0.tgz",
+      "integrity": "sha512-cL7Vo/QSpGx/DDmFxjeV0Qlyi1atvHQDPn3MLBBmi1icu+3GKZkCMAJwzsrV3U4+WoVoDYT9FJ9yMQf2HaIjeQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.190.0.tgz",
+      "integrity": "sha512-rrfLGYSZCBtiXNrIa8pJ2uwUoUMyj6Q82E8zmduTvqKWviCr6ZKes0lttGIkWhjvhql2m4CbjG5MPBnY7RXL4A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.190.0.tgz",
+      "integrity": "sha512-5tc1AIIZe5jDNdyuJW+7vIFmQOxz3q031ZVrEtUEIF7cz2ySho2lkOWziz+v+UGSLhjHGKMz3V26+aN1FLZNxQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.190.0.tgz",
+      "integrity": "sha512-h1bPopkncf2ue/erJdhqvgR2AEh0bIvkNsIHhx93DckWKotZd/GAVDq0gpKj7/f/7B+teHH8Fg5GDOwOOGyKcg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/service-error-classification": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-middleware": "3.190.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.190.0.tgz",
+      "integrity": "sha512-eUHrsr35mkD/cAFKoYuFYz0zE7QPBWvSzMzqmEJC+YXzAF6IABP3FL/htAFpWkje5XDl5dQ6dAxzV+ebK8RNXQ==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/signature-v4": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.190.0.tgz",
+      "integrity": "sha512-S132hEOK4jwbtZ1bGAgSuQ0DMFG4TiD4ulAwbQRBYooC7tiWZbRiR0Pkt2hV8d7WhOHgUpg7rvqlA7/HXXBAsA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.190.0.tgz",
+      "integrity": "sha512-Xj5MmXZq8UIpY8wOwyqei5q6MgqKxsO9Plo2zUgW7JR0w7R21MlqY2kzzvcM9R0FFhi9dqhniFT2ZMRUb1v73w==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/signature-v4": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-middleware": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.190.0.tgz",
+      "integrity": "sha512-h1mqiWNJdi1OTSEY8QovpiHgDQEeRG818v8yShpqSYXJKEqdn54MA3Z1D2fg/Wv/8ZJsFrBCiI7waT1JUYOmCg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.190.0.tgz",
+      "integrity": "sha512-y/2cTE1iYHKR0nkb3DvR3G8vt12lcTP95r/iHp8ZO+Uzpc25jM/AyMHWr2ZjqQiHKNlzh8uRw1CmQtgg4sBxXQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.190.0.tgz",
+      "integrity": "sha512-TJPUchyeK5KeEXWrwb6oW5/OkY3STCSGR1QIlbPcaTGkbo4kXAVyQmmZsY4KtRPuDM6/HlfUQV17bD716K65rQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/shared-ini-file-loader": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.190.0.tgz",
+      "integrity": "sha512-3Klkr73TpZkCzcnSP+gmFF0Baluzk3r7BaWclJHqt2LcFUWfIJzYlnbBQNZ4t3EEq7ZlBJX85rIDHBRlS+rUyA==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/querystring-builder": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/property-provider": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.190.0.tgz",
+      "integrity": "sha512-uzdKjHE2blbuceTC5zeBgZ0+Uo/hf9pH20CHpJeVNtrrtF3GALtu4Y1Gu5QQVIQBz8gjHnqANx0XhfYzorv69Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+      "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.190.0.tgz",
+      "integrity": "sha512-w9mTKkCsaLIBC8EA4RAHrqethNGbf60CbpPzN/QM7yCV3ZZJAXkppFfjTVVOMbPaI8GUEOptJtzgqV68CRB7ow==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-uri-escape": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.190.0.tgz",
+      "integrity": "sha512-vCKP0s33VtS47LSYzEWRRr2aTbi3qNkUuQyIrc5LMqBfS5hsy79P1HL4Q7lCVqZB5fe61N8fKzOxDxWRCF0sXg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.190.0.tgz",
+      "integrity": "sha512-g+s6xtaMa5fCMA2zJQC4BiFGMP7FN5/L1V/UwxCnKy8skCwaN0K5A1tFffBjjbYiPI7Gu7LVorWD2A0Y4xl01Q==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.190.0.tgz",
+      "integrity": "sha512-CZC/xsGReUEl5w+JgfancrxfkaCbEisyIFy6HALUYrioWQe80WMqLAdUMZSXHWjIaNK9mH0J/qvcSV2MuIoMzQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.190.0.tgz",
+      "integrity": "sha512-L/R/1X2T+/Kg2k/sjoYyDFulVUGrVcRfyEKKVFIUNg0NwUtw5UKa1/gS7geTKcg4q8M2pd/v+OCBrge2X7phUw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.188.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-hex-encoding": "3.188.0",
+        "@aws-sdk/util-middleware": "3.190.0",
+        "@aws-sdk/util-uri-escape": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.190.0.tgz",
+      "integrity": "sha512-f5EoCwjBLXMyuN491u1NmEutbolL0cJegaJbtgK9OJw2BLuRHiBknjDF4OEVuK/WqK0kz2JLMGi9xwVPl4BKCA==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/url-parser": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.190.0.tgz",
+      "integrity": "sha512-FKFDtxA9pvHmpfWmNVK5BAVRpDgkWMz3u4Sg9UzB+WAFN6UexRypXXUZCFAo8S04FbPKfYOR3O0uVlw7kzmj9g==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
+      "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.188.0.tgz",
+      "integrity": "sha512-r1dccRsRjKq+OhVRUfqFiW3sGgZBjHbMeHLbrAs9jrOjU2PTQ8PSzAXLvX/9lmp7YjmX17Qvlsg0NCr1tbB9OA==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.188.0.tgz",
+      "integrity": "sha512-XwqP3vxk60MKp4YDdvDeCD6BPOiG2e+/Ou4AofZOy5/toB6NKz2pFNibQIUg2+jc7mPMnGnvOW3MQEgSJ+gu/Q==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
+      "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.188.0.tgz",
+      "integrity": "sha512-LBA7tLbi7v4uvbOJhSnjJrxbcRifKK/1ZVK94JTV2MNSCCyNkFotyEI5UWDl10YKriTIUyf7o5cakpiDZ3O4xg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.190.0.tgz",
+      "integrity": "sha512-FKxTU4tIbFk2pdUbBNneStF++j+/pB4NYJ1HRSEAb/g4D2+kxikR/WKIv3p0JTVvAkwcuX/ausILYEPUyDZ4HQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.190.0.tgz",
+      "integrity": "sha512-qBiIMjNynqAP7p6urG1+ZattYkFaylhyinofVcLEiDvM9a6zGt6GZsxru2Loq0kRAXXGew9E9BWGt45HcDc20g==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.190.0",
+        "@aws-sdk/credential-provider-imds": "3.190.0",
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
+      "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.190.0.tgz",
+      "integrity": "sha512-qzTJ/qhFDzHZS+iXdHydQ/0sWAuNIB5feeLm55Io/I8Utv3l3TKYOhbgGwTsXY+jDk7oD+YnAi7hLN5oEBCwpg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
+      "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.190.0.tgz",
+      "integrity": "sha512-c074wjsD+/u9vT7DVrBLkwVhn28I+OEHuHaqpTVCvAIjpueZ3oms0e99YJLfpdpEgdLavOroAsNFtAuRrrTZZw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.190.0.tgz",
+      "integrity": "sha512-R36BMvvPX8frqFhU4lAsrOJ/2PJEHH/Jz1WZzO3GWmVSEAQQdHmo8tVPE3KOM7mZWe5Hj1dZudFAIxWHHFYKJA==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.188.0.tgz",
+      "integrity": "sha512-hCgP4+C0Lekjpjt2zFJ2R/iHes5sBGljXa5bScOFAEkRUc0Qw0VNgTv7LpEbIOAwGmqyxBoCwBW0YHPW1DfmYQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
     "node_modules/@aws-sdk/client-s3/node_modules/tslib": {
       "version": "2.4.0",
       "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.169.0",
@@ -505,81 +1265,142 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/eventstream-codec": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.190.0.tgz",
+      "integrity": "sha512-F1ux94fMKUrlOfJR/1x8p5+lisfemKizNSRtMnj0kcR+Y9vIt9bUodFyuDF8tJl/7iwnop6EPiGc3QA1IKjBKA==",
       "dependencies": {
         "@aws-crypto/crc32": "2.0.0",
-        "@aws-sdk/types": "3.168.0",
-        "@aws-sdk/util-hex-encoding": "3.168.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-hex-encoding": "3.188.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-codec/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-codec/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
+      "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-codec/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/eventstream-serde-browser": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.190.0.tgz",
+      "integrity": "sha512-aUsbLLPi3dtafnpIJtGbpCe8fhABIsVV49V1jJx6gQDAs6HG5IhO3LfndF05H6UbMyt8sDS6223wSt6HFUSHjQ==",
       "dependencies": {
-        "@aws-sdk/eventstream-serde-universal": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/eventstream-serde-universal": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-browser/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-browser/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.190.0.tgz",
+      "integrity": "sha512-etlsbvG8KSFQpGzoNazJoNPnN3P/i+IgIo/5D8pEl4R7gkjLAHZYnbk299xfv59olDWn9SVdrZfVx8lS+lUWHA==",
       "dependencies": {
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-config-resolver/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-config-resolver/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/eventstream-serde-node": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.190.0.tgz",
+      "integrity": "sha512-CmZ1jZJPar1uZAbfMrv00fzGk4NIc+1w4lRxOc0oow18pPSXsUAmefJKcW5ETX609xaH47nO5b7pTuHU8eGgzg==",
       "dependencies": {
-        "@aws-sdk/eventstream-serde-universal": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/eventstream-serde-universal": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-node/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-node/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/eventstream-serde-universal": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.190.0.tgz",
+      "integrity": "sha512-pioZzWDjjhfCfRIUr5oQdghUMdQV6KtP3lBrOO6rBCFCBOQjnQafqH+a+xRjEw19YvBpMX3tFUrVrUytCN9TDQ==",
       "dependencies": {
-        "@aws-sdk/eventstream-codec": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/eventstream-codec": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/@aws-sdk/eventstream-serde-universal/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/eventstream-serde-universal/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/fetch-http-handler": {
       "version": "3.168.0",
@@ -597,18 +1418,28 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/hash-blob-browser": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.190.0.tgz",
+      "integrity": "sha512-qRIoUGsy6S6kmqi0LQ+Ma9L5HKm8lIt002z+Yhb4kRTf6PFBWa/A0mDyrcj6L3MV71QGKfAEacV5nrVMF/aIhw==",
       "dependencies": {
-        "@aws-sdk/chunked-blob-reader": "3.168.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/chunked-blob-reader": "3.188.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.188.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/hash-blob-browser/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/hash-blob-browser/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/hash-node": {
       "version": "3.168.0",
@@ -627,19 +1458,29 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/hash-stream-node": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.190.0.tgz",
+      "integrity": "sha512-Itdqn0tRx5bS9A1vy/GzvAtg+KeBwg1MTeiefJQrGsIzh7KitvbFpcDlHZBvId6HPLI0c0aIORucwi9ayEOqjQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/@aws-sdk/hash-stream-node/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/hash-stream-node/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/invalid-dependency": {
       "version": "3.168.0",
@@ -668,27 +1509,112 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/md5-js": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.190.0.tgz",
+      "integrity": "sha512-zeyHnFzKYOgpAS1O+RfLyTRTjo0yLTw3Hooh/GjyuScfjwYG4UqP9kgZHnNLjHS9gXBahtskBOHaBCBGNTVLdw==",
       "dependencies": {
-        "@aws-sdk/types": "3.168.0",
-        "@aws-sdk/util-utf8-browser": "3.168.0",
-        "@aws-sdk/util-utf8-node": "3.168.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.188.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/md5-js/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
+      "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/md5-js/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/md5-js/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
+      "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/md5-js/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/md5-js/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.188.0.tgz",
+      "integrity": "sha512-hCgP4+C0Lekjpjt2zFJ2R/iHes5sBGljXa5bScOFAEkRUc0Qw0VNgTv7LpEbIOAwGmqyxBoCwBW0YHPW1DfmYQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/md5-js/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.190.0.tgz",
+      "integrity": "sha512-p1ItehR+NEEBpfPxRpq6VB12qIMWvs/D9ROLRltnIPC6Cf5H0rqWFf2ewT36PkkpL17+rjbt89N7AXLkBgU9NA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
-        "@aws-sdk/util-arn-parser": "3.168.0",
-        "@aws-sdk/util-config-provider": "3.168.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-arn-parser": "3.188.0",
+        "@aws-sdk/util-config-provider": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+      "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.188.0.tgz",
+      "integrity": "sha512-LBA7tLbi7v4uvbOJhSnjJrxbcRifKK/1ZVK94JTV2MNSCCyNkFotyEI5UWDl10YKriTIUyf7o5cakpiDZ3O4xg==",
+      "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -697,7 +1623,8 @@
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/middleware-content-length": {
       "version": "3.168.0",
@@ -716,39 +1643,94 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.190.0.tgz",
+      "integrity": "sha512-ZE3WY6RQ1uNuFgDn2KHfJXiLbwYgK/a4LX3SWNsO5gCrf9qchHTotkAc8PjFS5x4WV7TkddvhL2i57eikf1cYg==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+      "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.190.0.tgz",
+      "integrity": "sha512-YcZC2KX5G00RPhZpzFHBru2t27OelKYFG96Tc4cNOnjFmi++t7p5m5ZItFgovv9gUI9vTiI/XBQ+kc1XQ769Xw==",
       "dependencies": {
         "@aws-crypto/crc32": "2.0.0",
         "@aws-crypto/crc32c": "2.0.0",
-        "@aws-sdk/is-array-buffer": "3.168.0",
-        "@aws-sdk/protocol-http": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/is-array-buffer": "3.188.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
+      "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+      "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.168.0",
@@ -767,19 +1749,29 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.190.0.tgz",
+      "integrity": "sha512-dJ9u7Jb51z9YZLlpvT61og4bzsArJ81cox1t1P990Bbbi+pvJWoiwhwTdLDZhGqTYYg9ZuPd1ajmM2d9NAG/CQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-location-constraint/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/middleware-logger": {
       "version": "3.168.0",
@@ -839,22 +1831,44 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.190.0.tgz",
+      "integrity": "sha512-ixN3OOnF95Pla2Q9c4EyUpZk0TR5yYGbV1/eZqz5M9n2Iy1t6H11ZYSmK0BH3YjWG6Tdqva0AIwCfuvoUXWGZg==",
       "dependencies": {
-        "@aws-sdk/middleware-bucket-endpoint": "3.168.0",
-        "@aws-sdk/protocol-http": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
-        "@aws-sdk/util-arn-parser": "3.168.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-arn-parser": "3.188.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+      "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
       "version": "3.168.0",
@@ -909,19 +1923,29 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.190.0.tgz",
+      "integrity": "sha512-nwggMCfXBmhcDIrV/oPeSeuE1FRk0xvi/2PBuYYhM+xnkfUYovYUcdJhGkNqt7U1Mk0+CR2VVwozreigfcLesg==",
       "dependencies": {
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-ssec/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/middleware-stack": {
       "version": "3.168.0",
@@ -1086,13 +2110,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.190.0.tgz",
+      "integrity": "sha512-i9BpqlY3kAF8l8amqJ4skyjrlBy4B3hhO4RPu1D1wF4+GsJ5JGZ638Y5bYMH90k7A7ycTDDgFWHJcAsm1b0fEQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.168.0",
-        "@aws-sdk/signature-v4": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
-        "@aws-sdk/util-arn-parser": "3.168.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/signature-v4": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-arn-parser": "3.188.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1107,9 +2132,90 @@
         }
       }
     },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
+      "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+      "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.190.0.tgz",
+      "integrity": "sha512-L/R/1X2T+/Kg2k/sjoYyDFulVUGrVcRfyEKKVFIUNg0NwUtw5UKa1/gS7geTKcg4q8M2pd/v+OCBrge2X7phUw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.188.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-hex-encoding": "3.188.0",
+        "@aws-sdk/util-middleware": "3.190.0",
+        "@aws-sdk/util-uri-escape": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
+      "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.190.0.tgz",
+      "integrity": "sha512-qzTJ/qhFDzHZS+iXdHydQ/0sWAuNIB5feeLm55Io/I8Utv3l3TKYOhbgGwTsXY+jDk7oD+YnAi7hLN5oEBCwpg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
+      "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/signature-v4/node_modules/tslib": {
       "version": "2.4.0",
@@ -1152,8 +2258,9 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.188.0.tgz",
+      "integrity": "sha512-q4nZzt/g3sRY9a3sj1PaNFwql5bXfKSW4fRy0zLdbZHcYdgq2oQfVsJTIlL9lUNjifkXiIsmk61Q16JExtrLyw==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -1163,7 +2270,8 @@
     },
     "node_modules/@aws-sdk/util-arn-parser/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/util-base64-browser": {
       "version": "3.168.0",
@@ -1324,28 +2432,208 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/util-stream-browser": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.190.0.tgz",
+      "integrity": "sha512-BqHUD+Bz780LM6lD2YLYsX1PZ+BqwkRYtSaw+ch8IvrnMWeAB1hzQWXRh+2NhMpe2IBw18IrrYB3kVmcyGgUtg==",
       "dependencies": {
-        "@aws-sdk/fetch-http-handler": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
-        "@aws-sdk/util-base64-browser": "3.168.0",
-        "@aws-sdk/util-hex-encoding": "3.168.0",
-        "@aws-sdk/util-utf8-browser": "3.168.0",
+        "@aws-sdk/fetch-http-handler": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-hex-encoding": "3.188.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.190.0.tgz",
+      "integrity": "sha512-5riRpKydARXAPLesTZm6eP6QKJ4HJGQ3k0Tepi3nvxHVx3UddkRNoX0pLS3rvbajkykWPNC2qdfRGApWlwOYsA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/querystring-builder": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+      "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.190.0.tgz",
+      "integrity": "sha512-w9mTKkCsaLIBC8EA4RAHrqethNGbf60CbpPzN/QM7yCV3ZZJAXkppFfjTVVOMbPaI8GUEOptJtzgqV68CRB7ow==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-uri-escape": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
+      "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
+      "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
+      "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dependencies": {
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-stream-browser/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/util-stream-node": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.190.0.tgz",
+      "integrity": "sha512-RJ7iQB43fSfGW+aPhdT5LfG5GtbenB7q8mQLiTdIoj4Hw+gwa90JagMX+NxZv6DEkT4IgbT4q9liPQ48M83/YA==",
       "dependencies": {
-        "@aws-sdk/node-http-handler": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
-        "@aws-sdk/util-buffer-from": "3.168.0",
+        "@aws-sdk/node-http-handler": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-buffer-from": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.190.0.tgz",
+      "integrity": "sha512-M6qo2exTzEfHT5RuW7K090OgesUojhb2JyWiV4ulu7ngY4DWBUBMKUqac696sHRUZvGE5CDzSi0606DMboM+kA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
+      "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.190.0.tgz",
+      "integrity": "sha512-3Klkr73TpZkCzcnSP+gmFF0Baluzk3r7BaWclJHqt2LcFUWfIJzYlnbBQNZ4t3EEq7ZlBJX85rIDHBRlS+rUyA==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/querystring-builder": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+      "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.190.0.tgz",
+      "integrity": "sha512-w9mTKkCsaLIBC8EA4RAHrqethNGbf60CbpPzN/QM7yCV3ZZJAXkppFfjTVVOMbPaI8GUEOptJtzgqV68CRB7ow==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-uri-escape": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
+      "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
+      "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
+      "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1354,7 +2642,8 @@
     },
     "node_modules/@aws-sdk/util-stream-node/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/util-uri-escape": {
       "version": "3.168.0",
@@ -1434,24 +2723,47 @@
       "license": "0BSD"
     },
     "node_modules/@aws-sdk/util-waiter": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.190.0.tgz",
+      "integrity": "sha512-wlc56EElap8ua+9VCSqXaC4QsJQecYmC0C6A5EfFDtFlFyyd+vjpiLMU34juzrqJfVCx6aAUD2c9f+ezvk1G5Q==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/abort-controller": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-waiter/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.190.0.tgz",
+      "integrity": "sha512-M6qo2exTzEfHT5RuW7K090OgesUojhb2JyWiV4ulu7ngY4DWBUBMKUqac696sHRUZvGE5CDzSi0606DMboM+kA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-waiter/node_modules/@aws-sdk/types": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+      "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-waiter/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.168.0",
-      "license": "Apache-2.0",
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.188.0.tgz",
+      "integrity": "sha512-/Hah3gAtrBpEaDInX3eSS0nXw/IUeb+rWiGspXxb5O8bh5kyjQqeu8/sVJQlpOtq4aPDbMDmloH4k696qTqgbw==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -1461,7 +2773,8 @@
     },
     "node_modules/@aws-sdk/xml-builder/node_modules/tslib": {
       "version": "2.4.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -9759,6 +11072,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
     "node_modules/superagent": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.2.tgz",
@@ -12789,6 +14107,8 @@
     },
     "@aws-crypto/crc32": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
+      "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
       "requires": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -12797,6 +14117,8 @@
     },
     "@aws-crypto/crc32c": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
+      "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
       "requires": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -12868,25 +14190,41 @@
       }
     },
     "@aws-sdk/chunked-blob-reader": {
-      "version": "3.168.0",
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
+      "integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
       "requires": {
         "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.168.0",
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.188.0.tgz",
+      "integrity": "sha512-WielYjaAHfT/HAOW7Tj6yVeNdaOtts3aUm9Sf/3D+ElbCTGyaaMNfE4x0a+qn6dJZXewf1eAxybOIU5ftIeSGw==",
       "requires": {
-        "@aws-sdk/util-base64-browser": "3.168.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
+          "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -12935,66 +14273,659 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.169.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.190.0.tgz",
+      "integrity": "sha512-ngF92/X+odFt5Zbs5AWTozI+35fwFkHghbDABi5uSWNtgs2alSc/A94/yexbDdvVrVnuUa/FAMkvYX8duGZ9ig==",
       "requires": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.169.0",
-        "@aws-sdk/config-resolver": "3.168.0",
-        "@aws-sdk/credential-provider-node": "3.169.0",
-        "@aws-sdk/eventstream-serde-browser": "3.168.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.168.0",
-        "@aws-sdk/eventstream-serde-node": "3.168.0",
-        "@aws-sdk/fetch-http-handler": "3.168.0",
-        "@aws-sdk/hash-blob-browser": "3.168.0",
-        "@aws-sdk/hash-node": "3.168.0",
-        "@aws-sdk/hash-stream-node": "3.168.0",
-        "@aws-sdk/invalid-dependency": "3.168.0",
-        "@aws-sdk/md5-js": "3.168.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.168.0",
-        "@aws-sdk/middleware-content-length": "3.168.0",
-        "@aws-sdk/middleware-expect-continue": "3.168.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.168.0",
-        "@aws-sdk/middleware-host-header": "3.168.0",
-        "@aws-sdk/middleware-location-constraint": "3.168.0",
-        "@aws-sdk/middleware-logger": "3.168.0",
-        "@aws-sdk/middleware-recursion-detection": "3.168.0",
-        "@aws-sdk/middleware-retry": "3.169.0",
-        "@aws-sdk/middleware-sdk-s3": "3.168.0",
-        "@aws-sdk/middleware-serde": "3.168.0",
-        "@aws-sdk/middleware-signing": "3.168.0",
-        "@aws-sdk/middleware-ssec": "3.168.0",
-        "@aws-sdk/middleware-stack": "3.168.0",
-        "@aws-sdk/middleware-user-agent": "3.168.0",
-        "@aws-sdk/node-config-provider": "3.168.0",
-        "@aws-sdk/node-http-handler": "3.168.0",
-        "@aws-sdk/protocol-http": "3.168.0",
-        "@aws-sdk/signature-v4-multi-region": "3.168.0",
-        "@aws-sdk/smithy-client": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
-        "@aws-sdk/url-parser": "3.168.0",
-        "@aws-sdk/util-base64-browser": "3.168.0",
-        "@aws-sdk/util-base64-node": "3.168.0",
-        "@aws-sdk/util-body-length-browser": "3.168.0",
-        "@aws-sdk/util-body-length-node": "3.168.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.168.0",
-        "@aws-sdk/util-defaults-mode-node": "3.168.0",
-        "@aws-sdk/util-stream-browser": "3.168.0",
-        "@aws-sdk/util-stream-node": "3.168.0",
-        "@aws-sdk/util-user-agent-browser": "3.168.0",
-        "@aws-sdk/util-user-agent-node": "3.168.0",
-        "@aws-sdk/util-utf8-browser": "3.168.0",
-        "@aws-sdk/util-utf8-node": "3.168.0",
-        "@aws-sdk/util-waiter": "3.168.0",
-        "@aws-sdk/xml-builder": "3.168.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
+        "@aws-sdk/client-sts": "3.190.0",
+        "@aws-sdk/config-resolver": "3.190.0",
+        "@aws-sdk/credential-provider-node": "3.190.0",
+        "@aws-sdk/eventstream-serde-browser": "3.190.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.190.0",
+        "@aws-sdk/eventstream-serde-node": "3.190.0",
+        "@aws-sdk/fetch-http-handler": "3.190.0",
+        "@aws-sdk/hash-blob-browser": "3.190.0",
+        "@aws-sdk/hash-node": "3.190.0",
+        "@aws-sdk/hash-stream-node": "3.190.0",
+        "@aws-sdk/invalid-dependency": "3.190.0",
+        "@aws-sdk/md5-js": "3.190.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.190.0",
+        "@aws-sdk/middleware-content-length": "3.190.0",
+        "@aws-sdk/middleware-expect-continue": "3.190.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.190.0",
+        "@aws-sdk/middleware-host-header": "3.190.0",
+        "@aws-sdk/middleware-location-constraint": "3.190.0",
+        "@aws-sdk/middleware-logger": "3.190.0",
+        "@aws-sdk/middleware-recursion-detection": "3.190.0",
+        "@aws-sdk/middleware-retry": "3.190.0",
+        "@aws-sdk/middleware-sdk-s3": "3.190.0",
+        "@aws-sdk/middleware-serde": "3.190.0",
+        "@aws-sdk/middleware-signing": "3.190.0",
+        "@aws-sdk/middleware-ssec": "3.190.0",
+        "@aws-sdk/middleware-stack": "3.190.0",
+        "@aws-sdk/middleware-user-agent": "3.190.0",
+        "@aws-sdk/node-config-provider": "3.190.0",
+        "@aws-sdk/node-http-handler": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/signature-v4-multi-region": "3.190.0",
+        "@aws-sdk/smithy-client": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/url-parser": "3.190.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-base64-node": "3.188.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.188.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.190.0",
+        "@aws-sdk/util-defaults-mode-node": "3.190.0",
+        "@aws-sdk/util-stream-browser": "3.190.0",
+        "@aws-sdk/util-stream-node": "3.190.0",
+        "@aws-sdk/util-user-agent-browser": "3.190.0",
+        "@aws-sdk/util-user-agent-node": "3.190.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.188.0",
+        "@aws-sdk/util-waiter": "3.190.0",
+        "@aws-sdk/xml-builder": "3.188.0",
+        "fast-xml-parser": "4.0.11",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.190.0.tgz",
+          "integrity": "sha512-M6qo2exTzEfHT5RuW7K090OgesUojhb2JyWiV4ulu7ngY4DWBUBMKUqac696sHRUZvGE5CDzSi0606DMboM+kA==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.190.0.tgz",
+          "integrity": "sha512-joEKRjJEzgvXnEih/x2UDDCPlvXWCO3MAHmqi44yJ36Ph4YsFS299mOjPdVLuzUtpQ+cST1nRO7hXNFrulW2jQ==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.190.0",
+            "@aws-sdk/fetch-http-handler": "3.190.0",
+            "@aws-sdk/hash-node": "3.190.0",
+            "@aws-sdk/invalid-dependency": "3.190.0",
+            "@aws-sdk/middleware-content-length": "3.190.0",
+            "@aws-sdk/middleware-host-header": "3.190.0",
+            "@aws-sdk/middleware-logger": "3.190.0",
+            "@aws-sdk/middleware-recursion-detection": "3.190.0",
+            "@aws-sdk/middleware-retry": "3.190.0",
+            "@aws-sdk/middleware-serde": "3.190.0",
+            "@aws-sdk/middleware-stack": "3.190.0",
+            "@aws-sdk/middleware-user-agent": "3.190.0",
+            "@aws-sdk/node-config-provider": "3.190.0",
+            "@aws-sdk/node-http-handler": "3.190.0",
+            "@aws-sdk/protocol-http": "3.190.0",
+            "@aws-sdk/smithy-client": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "@aws-sdk/url-parser": "3.190.0",
+            "@aws-sdk/util-base64-browser": "3.188.0",
+            "@aws-sdk/util-base64-node": "3.188.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.188.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.190.0",
+            "@aws-sdk/util-defaults-mode-node": "3.190.0",
+            "@aws-sdk/util-user-agent-browser": "3.190.0",
+            "@aws-sdk/util-user-agent-node": "3.190.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.188.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.190.0.tgz",
+          "integrity": "sha512-s5MqfxqWxHAl1RhfQ6swjawsVPBqmq5F+SfzZcGLBCnVv03GaSL8J9K42O1Cc0+HwPQH2miY+Avy0zAr6VpY+Q==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.190.0",
+            "@aws-sdk/credential-provider-node": "3.190.0",
+            "@aws-sdk/fetch-http-handler": "3.190.0",
+            "@aws-sdk/hash-node": "3.190.0",
+            "@aws-sdk/invalid-dependency": "3.190.0",
+            "@aws-sdk/middleware-content-length": "3.190.0",
+            "@aws-sdk/middleware-host-header": "3.190.0",
+            "@aws-sdk/middleware-logger": "3.190.0",
+            "@aws-sdk/middleware-recursion-detection": "3.190.0",
+            "@aws-sdk/middleware-retry": "3.190.0",
+            "@aws-sdk/middleware-sdk-sts": "3.190.0",
+            "@aws-sdk/middleware-serde": "3.190.0",
+            "@aws-sdk/middleware-signing": "3.190.0",
+            "@aws-sdk/middleware-stack": "3.190.0",
+            "@aws-sdk/middleware-user-agent": "3.190.0",
+            "@aws-sdk/node-config-provider": "3.190.0",
+            "@aws-sdk/node-http-handler": "3.190.0",
+            "@aws-sdk/protocol-http": "3.190.0",
+            "@aws-sdk/smithy-client": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "@aws-sdk/url-parser": "3.190.0",
+            "@aws-sdk/util-base64-browser": "3.188.0",
+            "@aws-sdk/util-base64-node": "3.188.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.188.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.190.0",
+            "@aws-sdk/util-defaults-mode-node": "3.190.0",
+            "@aws-sdk/util-user-agent-browser": "3.190.0",
+            "@aws-sdk/util-user-agent-node": "3.190.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.188.0",
+            "fast-xml-parser": "4.0.11",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.190.0.tgz",
+          "integrity": "sha512-K+VnDtjTgjpf7yHEdDB0qgGbHToF0pIL0pQMSnmk2yc8BoB3LGG/gg1T0Ki+wRlrFnDCJ6L+8zUdawY2qDsbyw==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "@aws-sdk/util-config-provider": "3.188.0",
+            "@aws-sdk/util-middleware": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.190.0.tgz",
+          "integrity": "sha512-GTY7l3SJhTmRGFpWddbdJOihSqoMN8JMo3CsCtIjk4/h3xirBi02T4GSvbrMyP7FP3Fdl4NAdT+mHJ4q2Bvzxw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.190.0.tgz",
+          "integrity": "sha512-gI5pfBqGYCKdmx8igPvq+jLzyE2kuNn9Q5u73pdM/JZxiq7GeWYpE/MqqCubHxPtPcTFgAwxCxCFoXlUTBh/2g==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.190.0",
+            "@aws-sdk/property-provider": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "@aws-sdk/url-parser": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.190.0.tgz",
+          "integrity": "sha512-Z7NN/evXJk59hBQlfOSWDfHntwmxwryu6uclgv7ECI6SEVtKt1EKIlPuCLUYgQ4lxb9bomyO5lQAl/1WutNT5w==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.190.0",
+            "@aws-sdk/credential-provider-imds": "3.190.0",
+            "@aws-sdk/credential-provider-sso": "3.190.0",
+            "@aws-sdk/credential-provider-web-identity": "3.190.0",
+            "@aws-sdk/property-provider": "3.190.0",
+            "@aws-sdk/shared-ini-file-loader": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.190.0.tgz",
+          "integrity": "sha512-ctCG5+TsIK2gVgvvFiFjinPjc5nGpSypU3nQKCaihtPh83wDN6gCx4D0p9M8+fUrlPa5y+o/Y7yHo94ATepM8w==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.190.0",
+            "@aws-sdk/credential-provider-imds": "3.190.0",
+            "@aws-sdk/credential-provider-ini": "3.190.0",
+            "@aws-sdk/credential-provider-process": "3.190.0",
+            "@aws-sdk/credential-provider-sso": "3.190.0",
+            "@aws-sdk/credential-provider-web-identity": "3.190.0",
+            "@aws-sdk/property-provider": "3.190.0",
+            "@aws-sdk/shared-ini-file-loader": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.190.0.tgz",
+          "integrity": "sha512-sIJhICR80n5XY1kW/EFHTh5ZzBHb5X+744QCH3StcbKYI44mOZvNKfFdeRL2fQ7yLgV7npte2HJRZzQPWpZUrw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.190.0",
+            "@aws-sdk/shared-ini-file-loader": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.190.0.tgz",
+          "integrity": "sha512-uarU9vk471MHHT+GJj3KWFSmaaqLNL5n1KcMer2CCAZfjs+mStAi8+IjZuuKXB4vqVs5DxdH8cy5aLaJcBlXwQ==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.190.0",
+            "@aws-sdk/property-provider": "3.190.0",
+            "@aws-sdk/shared-ini-file-loader": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.190.0.tgz",
+          "integrity": "sha512-nlIBeK9hGHKWC874h+ITAfPZ9Eaok+x/ydZQVKsLHiQ9PH3tuQ8AaGqhuCwBSH0hEAHZ/BiKeEx5VyWAE8/x+Q==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.190.0.tgz",
+          "integrity": "sha512-5riRpKydARXAPLesTZm6eP6QKJ4HJGQ3k0Tepi3nvxHVx3UddkRNoX0pLS3rvbajkykWPNC2qdfRGApWlwOYsA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.190.0",
+            "@aws-sdk/querystring-builder": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "@aws-sdk/util-base64-browser": "3.188.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.190.0.tgz",
+          "integrity": "sha512-DNwVT3O8zc9Jk/bXiXcN0WsD98r+JJWryw9F1/ZZbuzbf6rx2qhI8ZK+nh5X6WMtYPU84luQMcF702fJt/1bzg==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "@aws-sdk/util-buffer-from": "3.188.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.190.0.tgz",
+          "integrity": "sha512-crCh63e8d/Uw9y3dQlVTPja7+IZiXpNXyH6oSuAadTDQwMq6KK87Av1/SDzVf6bAo2KgAOo41MyO2joaCEk0dQ==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
+          "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.190.0.tgz",
+          "integrity": "sha512-sSU347SuC6I8kWum1jlJlpAqeV23KP7enG+ToWcEcgFrJhm3AvuqB//NJxDbkKb2DNroRvJjBckBvrwNAjQnBQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.190.0.tgz",
+          "integrity": "sha512-cL7Vo/QSpGx/DDmFxjeV0Qlyi1atvHQDPn3MLBBmi1icu+3GKZkCMAJwzsrV3U4+WoVoDYT9FJ9yMQf2HaIjeQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.190.0.tgz",
+          "integrity": "sha512-rrfLGYSZCBtiXNrIa8pJ2uwUoUMyj6Q82E8zmduTvqKWviCr6ZKes0lttGIkWhjvhql2m4CbjG5MPBnY7RXL4A==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.190.0.tgz",
+          "integrity": "sha512-5tc1AIIZe5jDNdyuJW+7vIFmQOxz3q031ZVrEtUEIF7cz2ySho2lkOWziz+v+UGSLhjHGKMz3V26+aN1FLZNxQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.190.0.tgz",
+          "integrity": "sha512-h1bPopkncf2ue/erJdhqvgR2AEh0bIvkNsIHhx93DckWKotZd/GAVDq0gpKj7/f/7B+teHH8Fg5GDOwOOGyKcg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.190.0",
+            "@aws-sdk/service-error-classification": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "@aws-sdk/util-middleware": "3.190.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.190.0.tgz",
+          "integrity": "sha512-eUHrsr35mkD/cAFKoYuFYz0zE7QPBWvSzMzqmEJC+YXzAF6IABP3FL/htAFpWkje5XDl5dQ6dAxzV+ebK8RNXQ==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.190.0",
+            "@aws-sdk/property-provider": "3.190.0",
+            "@aws-sdk/protocol-http": "3.190.0",
+            "@aws-sdk/signature-v4": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.190.0.tgz",
+          "integrity": "sha512-S132hEOK4jwbtZ1bGAgSuQ0DMFG4TiD4ulAwbQRBYooC7tiWZbRiR0Pkt2hV8d7WhOHgUpg7rvqlA7/HXXBAsA==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.190.0.tgz",
+          "integrity": "sha512-Xj5MmXZq8UIpY8wOwyqei5q6MgqKxsO9Plo2zUgW7JR0w7R21MlqY2kzzvcM9R0FFhi9dqhniFT2ZMRUb1v73w==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.190.0",
+            "@aws-sdk/protocol-http": "3.190.0",
+            "@aws-sdk/signature-v4": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "@aws-sdk/util-middleware": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.190.0.tgz",
+          "integrity": "sha512-h1mqiWNJdi1OTSEY8QovpiHgDQEeRG818v8yShpqSYXJKEqdn54MA3Z1D2fg/Wv/8ZJsFrBCiI7waT1JUYOmCg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.190.0.tgz",
+          "integrity": "sha512-y/2cTE1iYHKR0nkb3DvR3G8vt12lcTP95r/iHp8ZO+Uzpc25jM/AyMHWr2ZjqQiHKNlzh8uRw1CmQtgg4sBxXQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.190.0.tgz",
+          "integrity": "sha512-TJPUchyeK5KeEXWrwb6oW5/OkY3STCSGR1QIlbPcaTGkbo4kXAVyQmmZsY4KtRPuDM6/HlfUQV17bD716K65rQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.190.0",
+            "@aws-sdk/shared-ini-file-loader": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.190.0.tgz",
+          "integrity": "sha512-3Klkr73TpZkCzcnSP+gmFF0Baluzk3r7BaWclJHqt2LcFUWfIJzYlnbBQNZ4t3EEq7ZlBJX85rIDHBRlS+rUyA==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.190.0",
+            "@aws-sdk/protocol-http": "3.190.0",
+            "@aws-sdk/querystring-builder": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.190.0.tgz",
+          "integrity": "sha512-uzdKjHE2blbuceTC5zeBgZ0+Uo/hf9pH20CHpJeVNtrrtF3GALtu4Y1Gu5QQVIQBz8gjHnqANx0XhfYzorv69Q==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+          "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.190.0.tgz",
+          "integrity": "sha512-w9mTKkCsaLIBC8EA4RAHrqethNGbf60CbpPzN/QM7yCV3ZZJAXkppFfjTVVOMbPaI8GUEOptJtzgqV68CRB7ow==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "@aws-sdk/util-uri-escape": "3.188.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.190.0.tgz",
+          "integrity": "sha512-vCKP0s33VtS47LSYzEWRRr2aTbi3qNkUuQyIrc5LMqBfS5hsy79P1HL4Q7lCVqZB5fe61N8fKzOxDxWRCF0sXg==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.190.0.tgz",
+          "integrity": "sha512-g+s6xtaMa5fCMA2zJQC4BiFGMP7FN5/L1V/UwxCnKy8skCwaN0K5A1tFffBjjbYiPI7Gu7LVorWD2A0Y4xl01Q=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.190.0.tgz",
+          "integrity": "sha512-CZC/xsGReUEl5w+JgfancrxfkaCbEisyIFy6HALUYrioWQe80WMqLAdUMZSXHWjIaNK9mH0J/qvcSV2MuIoMzQ==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.190.0.tgz",
+          "integrity": "sha512-L/R/1X2T+/Kg2k/sjoYyDFulVUGrVcRfyEKKVFIUNg0NwUtw5UKa1/gS7geTKcg4q8M2pd/v+OCBrge2X7phUw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.188.0",
+            "@aws-sdk/types": "3.190.0",
+            "@aws-sdk/util-hex-encoding": "3.188.0",
+            "@aws-sdk/util-middleware": "3.190.0",
+            "@aws-sdk/util-uri-escape": "3.188.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.190.0.tgz",
+          "integrity": "sha512-f5EoCwjBLXMyuN491u1NmEutbolL0cJegaJbtgK9OJw2BLuRHiBknjDF4OEVuK/WqK0kz2JLMGi9xwVPl4BKCA==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.190.0.tgz",
+          "integrity": "sha512-FKFDtxA9pvHmpfWmNVK5BAVRpDgkWMz3u4Sg9UzB+WAFN6UexRypXXUZCFAo8S04FbPKfYOR3O0uVlw7kzmj9g==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
+          "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-base64-node": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.188.0.tgz",
+          "integrity": "sha512-r1dccRsRjKq+OhVRUfqFiW3sGgZBjHbMeHLbrAs9jrOjU2PTQ8PSzAXLvX/9lmp7YjmX17Qvlsg0NCr1tbB9OA==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.188.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+          "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.188.0.tgz",
+          "integrity": "sha512-XwqP3vxk60MKp4YDdvDeCD6BPOiG2e+/Ou4AofZOy5/toB6NKz2pFNibQIUg2+jc7mPMnGnvOW3MQEgSJ+gu/Q==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
+          "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.188.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.188.0.tgz",
+          "integrity": "sha512-LBA7tLbi7v4uvbOJhSnjJrxbcRifKK/1ZVK94JTV2MNSCCyNkFotyEI5UWDl10YKriTIUyf7o5cakpiDZ3O4xg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.190.0.tgz",
+          "integrity": "sha512-FKxTU4tIbFk2pdUbBNneStF++j+/pB4NYJ1HRSEAb/g4D2+kxikR/WKIv3p0JTVvAkwcuX/ausILYEPUyDZ4HQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.190.0.tgz",
+          "integrity": "sha512-qBiIMjNynqAP7p6urG1+ZattYkFaylhyinofVcLEiDvM9a6zGt6GZsxru2Loq0kRAXXGew9E9BWGt45HcDc20g==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.190.0",
+            "@aws-sdk/credential-provider-imds": "3.190.0",
+            "@aws-sdk/node-config-provider": "3.190.0",
+            "@aws-sdk/property-provider": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
+          "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.190.0.tgz",
+          "integrity": "sha512-qzTJ/qhFDzHZS+iXdHydQ/0sWAuNIB5feeLm55Io/I8Utv3l3TKYOhbgGwTsXY+jDk7oD+YnAi7hLN5oEBCwpg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
+          "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.190.0.tgz",
+          "integrity": "sha512-c074wjsD+/u9vT7DVrBLkwVhn28I+OEHuHaqpTVCvAIjpueZ3oms0e99YJLfpdpEgdLavOroAsNFtAuRrrTZZw==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.190.0.tgz",
+          "integrity": "sha512-R36BMvvPX8frqFhU4lAsrOJ/2PJEHH/Jz1WZzO3GWmVSEAQQdHmo8tVPE3KOM7mZWe5Hj1dZudFAIxWHHFYKJA==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+          "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.188.0.tgz",
+          "integrity": "sha512-hCgP4+C0Lekjpjt2zFJ2R/iHes5sBGljXa5bScOFAEkRUc0Qw0VNgTv7LpEbIOAwGmqyxBoCwBW0YHPW1DfmYQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.188.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.0.11",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+          "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        },
         "tslib": {
           "version": "2.4.0"
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -13209,67 +15140,120 @@
       }
     },
     "@aws-sdk/eventstream-codec": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.190.0.tgz",
+      "integrity": "sha512-F1ux94fMKUrlOfJR/1x8p5+lisfemKizNSRtMnj0kcR+Y9vIt9bUodFyuDF8tJl/7iwnop6EPiGc3QA1IKjBKA==",
       "requires": {
         "@aws-crypto/crc32": "2.0.0",
-        "@aws-sdk/types": "3.168.0",
-        "@aws-sdk/util-hex-encoding": "3.168.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-hex-encoding": "3.188.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
+          "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@aws-sdk/eventstream-serde-browser": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.190.0.tgz",
+      "integrity": "sha512-aUsbLLPi3dtafnpIJtGbpCe8fhABIsVV49V1jJx6gQDAs6HG5IhO3LfndF05H6UbMyt8sDS6223wSt6HFUSHjQ==",
       "requires": {
-        "@aws-sdk/eventstream-serde-universal": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/eventstream-serde-universal": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.190.0.tgz",
+      "integrity": "sha512-etlsbvG8KSFQpGzoNazJoNPnN3P/i+IgIo/5D8pEl4R7gkjLAHZYnbk299xfv59olDWn9SVdrZfVx8lS+lUWHA==",
       "requires": {
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@aws-sdk/eventstream-serde-node": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.190.0.tgz",
+      "integrity": "sha512-CmZ1jZJPar1uZAbfMrv00fzGk4NIc+1w4lRxOc0oow18pPSXsUAmefJKcW5ETX609xaH47nO5b7pTuHU8eGgzg==",
       "requires": {
-        "@aws-sdk/eventstream-serde-universal": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/eventstream-serde-universal": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@aws-sdk/eventstream-serde-universal": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.190.0.tgz",
+      "integrity": "sha512-pioZzWDjjhfCfRIUr5oQdghUMdQV6KtP3lBrOO6rBCFCBOQjnQafqH+a+xRjEw19YvBpMX3tFUrVrUytCN9TDQ==",
       "requires": {
-        "@aws-sdk/eventstream-codec": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/eventstream-codec": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -13289,16 +15273,25 @@
       }
     },
     "@aws-sdk/hash-blob-browser": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.190.0.tgz",
+      "integrity": "sha512-qRIoUGsy6S6kmqi0LQ+Ma9L5HKm8lIt002z+Yhb4kRTf6PFBWa/A0mDyrcj6L3MV71QGKfAEacV5nrVMF/aIhw==",
       "requires": {
-        "@aws-sdk/chunked-blob-reader": "3.168.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/chunked-blob-reader": "3.188.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.188.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -13316,14 +15309,23 @@
       }
     },
     "@aws-sdk/hash-stream-node": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.190.0.tgz",
+      "integrity": "sha512-Itdqn0tRx5bS9A1vy/GzvAtg+KeBwg1MTeiefJQrGsIzh7KitvbFpcDlHZBvId6HPLI0c0aIORucwi9ayEOqjQ==",
       "requires": {
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -13351,31 +15353,100 @@
       }
     },
     "@aws-sdk/md5-js": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.190.0.tgz",
+      "integrity": "sha512-zeyHnFzKYOgpAS1O+RfLyTRTjo0yLTw3Hooh/GjyuScfjwYG4UqP9kgZHnNLjHS9gXBahtskBOHaBCBGNTVLdw==",
       "requires": {
-        "@aws-sdk/types": "3.168.0",
-        "@aws-sdk/util-utf8-browser": "3.168.0",
-        "@aws-sdk/util-utf8-node": "3.168.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.188.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
+          "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
+          "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.188.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+          "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.188.0.tgz",
+          "integrity": "sha512-hCgP4+C0Lekjpjt2zFJ2R/iHes5sBGljXa5bScOFAEkRUc0Qw0VNgTv7LpEbIOAwGmqyxBoCwBW0YHPW1DfmYQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.188.0",
+            "tslib": "^2.3.1"
+          }
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.190.0.tgz",
+      "integrity": "sha512-p1ItehR+NEEBpfPxRpq6VB12qIMWvs/D9ROLRltnIPC6Cf5H0rqWFf2ewT36PkkpL17+rjbt89N7AXLkBgU9NA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
-        "@aws-sdk/util-arn-parser": "3.168.0",
-        "@aws-sdk/util-config-provider": "3.168.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-arn-parser": "3.188.0",
+        "@aws-sdk/util-config-provider": "3.188.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+          "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.188.0.tgz",
+          "integrity": "sha512-LBA7tLbi7v4uvbOJhSnjJrxbcRifKK/1ZVK94JTV2MNSCCyNkFotyEI5UWDl10YKriTIUyf7o5cakpiDZ3O4xg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -13393,31 +15464,75 @@
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.190.0.tgz",
+      "integrity": "sha512-ZE3WY6RQ1uNuFgDn2KHfJXiLbwYgK/a4LX3SWNsO5gCrf9qchHTotkAc8PjFS5x4WV7TkddvhL2i57eikf1cYg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+          "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.190.0.tgz",
+      "integrity": "sha512-YcZC2KX5G00RPhZpzFHBru2t27OelKYFG96Tc4cNOnjFmi++t7p5m5ZItFgovv9gUI9vTiI/XBQ+kc1XQ769Xw==",
       "requires": {
         "@aws-crypto/crc32": "2.0.0",
         "@aws-crypto/crc32c": "2.0.0",
-        "@aws-sdk/is-array-buffer": "3.168.0",
-        "@aws-sdk/protocol-http": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/is-array-buffer": "3.188.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
+          "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+          "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -13435,14 +15550,23 @@
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.190.0.tgz",
+      "integrity": "sha512-dJ9u7Jb51z9YZLlpvT61og4bzsArJ81cox1t1P990Bbbi+pvJWoiwhwTdLDZhGqTYYg9ZuPd1ajmM2d9NAG/CQ==",
       "requires": {
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -13491,17 +15615,35 @@
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.190.0.tgz",
+      "integrity": "sha512-ixN3OOnF95Pla2Q9c4EyUpZk0TR5yYGbV1/eZqz5M9n2Iy1t6H11ZYSmK0BH3YjWG6Tdqva0AIwCfuvoUXWGZg==",
       "requires": {
-        "@aws-sdk/middleware-bucket-endpoint": "3.168.0",
-        "@aws-sdk/protocol-http": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
-        "@aws-sdk/util-arn-parser": "3.168.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-arn-parser": "3.188.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+          "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -13549,14 +15691,23 @@
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.190.0.tgz",
+      "integrity": "sha512-nwggMCfXBmhcDIrV/oPeSeuE1FRk0xvi/2PBuYYhM+xnkfUYovYUcdJhGkNqt7U1Mk0+CR2VVwozreigfcLesg==",
       "requires": {
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -13693,17 +15844,80 @@
       }
     },
     "@aws-sdk/signature-v4-multi-region": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.190.0.tgz",
+      "integrity": "sha512-i9BpqlY3kAF8l8amqJ4skyjrlBy4B3hhO4RPu1D1wF4+GsJ5JGZ638Y5bYMH90k7A7ycTDDgFWHJcAsm1b0fEQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.168.0",
-        "@aws-sdk/signature-v4": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
-        "@aws-sdk/util-arn-parser": "3.168.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/signature-v4": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-arn-parser": "3.188.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
+          "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+          "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.190.0.tgz",
+          "integrity": "sha512-L/R/1X2T+/Kg2k/sjoYyDFulVUGrVcRfyEKKVFIUNg0NwUtw5UKa1/gS7geTKcg4q8M2pd/v+OCBrge2X7phUw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.188.0",
+            "@aws-sdk/types": "3.190.0",
+            "@aws-sdk/util-hex-encoding": "3.188.0",
+            "@aws-sdk/util-middleware": "3.190.0",
+            "@aws-sdk/util-uri-escape": "3.188.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
+          "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.190.0.tgz",
+          "integrity": "sha512-qzTJ/qhFDzHZS+iXdHydQ/0sWAuNIB5feeLm55Io/I8Utv3l3TKYOhbgGwTsXY+jDk7oD+YnAi7hLN5oEBCwpg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
+          "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -13737,13 +15951,17 @@
       }
     },
     "@aws-sdk/util-arn-parser": {
-      "version": "3.168.0",
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.188.0.tgz",
+      "integrity": "sha512-q4nZzt/g3sRY9a3sj1PaNFwql5bXfKSW4fRy0zLdbZHcYdgq2oQfVsJTIlL9lUNjifkXiIsmk61Q16JExtrLyw==",
       "requires": {
         "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -13879,32 +16097,178 @@
       }
     },
     "@aws-sdk/util-stream-browser": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.190.0.tgz",
+      "integrity": "sha512-BqHUD+Bz780LM6lD2YLYsX1PZ+BqwkRYtSaw+ch8IvrnMWeAB1hzQWXRh+2NhMpe2IBw18IrrYB3kVmcyGgUtg==",
       "requires": {
-        "@aws-sdk/fetch-http-handler": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
-        "@aws-sdk/util-base64-browser": "3.168.0",
-        "@aws-sdk/util-hex-encoding": "3.168.0",
-        "@aws-sdk/util-utf8-browser": "3.168.0",
+        "@aws-sdk/fetch-http-handler": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-base64-browser": "3.188.0",
+        "@aws-sdk/util-hex-encoding": "3.188.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.190.0.tgz",
+          "integrity": "sha512-5riRpKydARXAPLesTZm6eP6QKJ4HJGQ3k0Tepi3nvxHVx3UddkRNoX0pLS3rvbajkykWPNC2qdfRGApWlwOYsA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.190.0",
+            "@aws-sdk/querystring-builder": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "@aws-sdk/util-base64-browser": "3.188.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+          "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.190.0.tgz",
+          "integrity": "sha512-w9mTKkCsaLIBC8EA4RAHrqethNGbf60CbpPzN/QM7yCV3ZZJAXkppFfjTVVOMbPaI8GUEOptJtzgqV68CRB7ow==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "@aws-sdk/util-uri-escape": "3.188.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
+          "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
+          "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
+          "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+          "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@aws-sdk/util-stream-node": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.190.0.tgz",
+      "integrity": "sha512-RJ7iQB43fSfGW+aPhdT5LfG5GtbenB7q8mQLiTdIoj4Hw+gwa90JagMX+NxZv6DEkT4IgbT4q9liPQ48M83/YA==",
       "requires": {
-        "@aws-sdk/node-http-handler": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
-        "@aws-sdk/util-buffer-from": "3.168.0",
+        "@aws-sdk/node-http-handler": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-buffer-from": "3.188.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.190.0.tgz",
+          "integrity": "sha512-M6qo2exTzEfHT5RuW7K090OgesUojhb2JyWiV4ulu7ngY4DWBUBMKUqac696sHRUZvGE5CDzSi0606DMboM+kA==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
+          "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.190.0.tgz",
+          "integrity": "sha512-3Klkr73TpZkCzcnSP+gmFF0Baluzk3r7BaWclJHqt2LcFUWfIJzYlnbBQNZ4t3EEq7ZlBJX85rIDHBRlS+rUyA==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.190.0",
+            "@aws-sdk/protocol-http": "3.190.0",
+            "@aws-sdk/querystring-builder": "3.190.0",
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.190.0.tgz",
+          "integrity": "sha512-s5MVfeONpfZYRzCSbqQ+wJ3GxKED+aSS7+CQoeaYoD6HDTDxaMGNv9aiPxVCzW02sgG7py7f29Q6Vw+5taZXZA==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.190.0.tgz",
+          "integrity": "sha512-w9mTKkCsaLIBC8EA4RAHrqethNGbf60CbpPzN/QM7yCV3ZZJAXkppFfjTVVOMbPaI8GUEOptJtzgqV68CRB7ow==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "@aws-sdk/util-uri-escape": "3.188.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
+          "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.188.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
+          "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -13969,26 +16333,48 @@
       }
     },
     "@aws-sdk/util-waiter": {
-      "version": "3.168.0",
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.190.0.tgz",
+      "integrity": "sha512-wlc56EElap8ua+9VCSqXaC4QsJQecYmC0C6A5EfFDtFlFyyd+vjpiLMU34juzrqJfVCx6aAUD2c9f+ezvk1G5Q==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.168.0",
-        "@aws-sdk/types": "3.168.0",
+        "@aws-sdk/abort-controller": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.190.0.tgz",
+          "integrity": "sha512-M6qo2exTzEfHT5RuW7K090OgesUojhb2JyWiV4ulu7ngY4DWBUBMKUqac696sHRUZvGE5CDzSi0606DMboM+kA==",
+          "requires": {
+            "@aws-sdk/types": "3.190.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.190.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.190.0.tgz",
+          "integrity": "sha512-mkeZ+vJZzElP6OdRXvuLKWHSlDQxZP9u8BjQB9N0Rw0pCXTzYS0vzIhN1pL0uddWp5fMrIE68snto9xNR6BQuA=="
+        },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@aws-sdk/xml-builder": {
-      "version": "3.168.0",
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.188.0.tgz",
+      "integrity": "sha512-/Hah3gAtrBpEaDInX3eSS0nXw/IUeb+rWiGspXxb5O8bh5kyjQqeu8/sVJQlpOtq4aPDbMDmloH4k696qTqgbw==",
       "requires": {
         "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -21132,6 +23518,11 @@
     },
     "strip-json-comments": {
       "version": "3.1.1"
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "superagent": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A lens into your GitHub organisation",
   "scripts": {
     "test": "jest --detectOpenHandles",
-    "start": "npm -w packages/repo-fetcher run dev",
+    "fetch": "npm -w packages/repo-fetcher run dev",
+    "localapi": "npm -w packages/github-lens-api run dev",
     "synth": "npm run synth --workspace=cdk",
     "typecheck": "npm run typecheck --workspaces",
     "build": "npm run build --workspace=repo-fetcher --workspace=github-lens-api",
@@ -20,6 +21,7 @@
     "aws-sdk-client-mock": "^2.0.0"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.190.0",
     "@types/jest": "^28.1.6",
     "@types/node": "^18.6.3",
     "dotenv": "^16.0.1",

--- a/packages/common/github/github.ts
+++ b/packages/common/github/github.ts
@@ -141,8 +141,6 @@ export const getTeamlistMembersInOrg = async (
 	);
 };
 
-//Get a team
-//SingleTeamResponse
 export const getTeamBySlug = async (
 	client: Octokit,
 	teamSlug: string,
@@ -155,9 +153,6 @@ export const getTeamBySlug = async (
 	return response.data;
 };
 
-//Get a single repository
-//https://octokit.github.io/rest.js/v19#repos
-//SingleRepoResponse
 export const getInfoForRepo = async (
 	client: Octokit,
 	owner: string,
@@ -171,11 +166,11 @@ export const getInfoForRepo = async (
 	return response.data;
 };
 
-let teamCounter = 0;
-const numberOfTeams = 2;
 export const listTeamsForLocalDevelopment = async (
 	client: Octokit,
 ): Promise<TeamsResponse> => {
+	let teamCounter = 0;
+	const numberOfTeams = 2;
 	return await client.paginate(
 		client.teams.list,
 		{
@@ -192,11 +187,11 @@ export const listTeamsForLocalDevelopment = async (
 	);
 };
 
-let repoCounter = 0;
-const numberOfRepos = 2;
 export const listRepositoriesForLocalDevelopment = async (
 	client: Octokit,
 ): Promise<RepositoriesResponse> => {
+	let repoCounter = 0;
+	const numberOfRepos = 2;
 	return await client.paginate(
 		client.repos.listForOrg,
 		{

--- a/packages/common/github/github.ts
+++ b/packages/common/github/github.ts
@@ -2,7 +2,7 @@ import { createAppAuth } from '@octokit/auth-app';
 import { throttling } from '@octokit/plugin-throttling';
 import { Octokit } from '@octokit/rest';
 import type { GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
-import type { Config } from '../config';
+import type { Config, Stage } from '../config';
 import { sleep } from '../sleep';
 
 const ThrottledOctokit = Octokit.plugin(throttling);
@@ -23,8 +23,20 @@ export type RepositoriesResponse = GetResponseDataTypeFromEndpointMethod<
 export type TeamsResponse = GetResponseDataTypeFromEndpointMethod<
 	typeof octokit.teams.list
 >;
+export type SingleTeamResponse = GetResponseDataTypeFromEndpointMethod<
+	typeof octokit.teams.getByName
+>;
+export type SingleRepoResponse = GetResponseDataTypeFromEndpointMethod<
+	typeof octokit.repos.get
+>;
 export type TeamRepoResponse = GetResponseDataTypeFromEndpointMethod<
 	typeof octokit.teams.listReposInOrg
+>;
+export type TeamRepoResponseAuth = GetResponseDataTypeFromEndpointMethod<
+	typeof octokit.teams.listForAuthenticatedUser
+>;
+export type MembersInOrgResponse = GetResponseDataTypeFromEndpointMethod<
+	typeof octokit.teams.listMembersInOrg
 >;
 export type RepositoryResponse = RepositoriesResponse[number];
 
@@ -99,17 +111,141 @@ export const listTeams = async (client: Octokit): Promise<TeamsResponse> => {
 	);
 };
 
+export const getTeamlistForAuthenticatedUser = async (
+	client: Octokit,
+	teamSlug: string,
+): Promise<TeamRepoResponseAuth> => {
+	return await client.paginate(
+		client.teams.listForAuthenticatedUser,
+		{
+			org: 'guardian',
+			team_slug: teamSlug,
+			per_page: defaultPageSize,
+		},
+		(response) => response.data,
+	);
+};
+
+export const getTeamlistMembersInOrg = async (
+	client: Octokit,
+	teamSlug: string,
+): Promise<MembersInOrgResponse> => {
+	return await client.paginate(
+		client.teams.listMembersInOrg,
+		{
+			org: 'guardian',
+			team_slug: teamSlug,
+			per_page: defaultPageSize,
+		},
+		(response) => response.data,
+	);
+};
+
+//Get a team
+//SingleTeamResponse
+export const getTeamBySlug = async (
+	client: Octokit,
+	teamSlug: string,
+): Promise<SingleTeamResponse> => {
+	const response = await client.teams.getByName({
+		org: 'guardian',
+		team_slug: teamSlug,
+		per_page: defaultPageSize,
+	});
+	return response.data;
+};
+
+//Get a single repository
+//https://octokit.github.io/rest.js/v19#repos
+//SingleRepoResponse
+export const getInfoForRepo = async (
+	client: Octokit,
+	owner: string,
+	repo: string,
+): Promise<SingleRepoResponse> => {
+	const response = await client.repos.get({
+		org: 'guardian',
+		owner: owner,
+		repo: repo,
+	});
+	return response.data;
+};
+
+let teamCounter = 0;
+const numberOfTeams = 2;
+export const listTeamsForLocalDevelopment = async (
+	client: Octokit,
+): Promise<TeamsResponse> => {
+	return await client.paginate(
+		client.teams.list,
+		{
+			org: 'guardian',
+			per_page: 1,
+		},
+		(response, done) => {
+			teamCounter += response.data.length;
+			if (teamCounter >= numberOfTeams) {
+				done();
+			}
+			return response.data;
+		},
+	);
+};
+
+let repoCounter = 0;
+const numberOfRepos = 2;
+export const listRepositoriesForLocalDevelopment = async (
+	client: Octokit,
+): Promise<RepositoriesResponse> => {
+	return await client.paginate(
+		client.repos.listForOrg,
+		{
+			org: 'guardian',
+			per_page: 1,
+		},
+		(response, done) => {
+			repoCounter += response.data.length;
+			if (repoCounter >= numberOfRepos) {
+				done();
+			}
+			return response.data;
+		},
+	);
+};
+
 export const getReposForTeam = async (
 	client: Octokit,
-	teamName: string,
+	teamSlug: string,
 ): Promise<TeamRepoResponse> => {
 	return await client.paginate(
 		client.teams.listReposInOrg,
 		{
 			org: 'guardian',
-			team_slug: teamName,
+			team_slug: teamSlug,
 			per_page: defaultPageSize,
 		},
 		(response) => response.data,
 	);
+};
+
+//get everything after all but save to file in dir test only once on DEV
+
+// export const getTeams = (stage: Stage, client: Octokit) => {
+// 	return stage === 'DEV'
+// 		? listTeamsForLocalDevelopment(client)
+// 		: listTeams(client);
+// };
+
+export const getTeams = (stage: Stage, client: Octokit) => {
+	return listTeams(client);
+};
+
+// export const getRepos = (stage: Stage, client: Octokit) => {
+// 	return stage === 'DEV'
+// 		? listRepositoriesForLocalDevelopment(client)
+// 		: listRepositories(client);
+// };
+
+export const getRepos = (stage: Stage, client: Octokit) => {
+	return listRepositories(client);
 };

--- a/packages/github-lens-api/src/app.ts
+++ b/packages/github-lens-api/src/app.ts
@@ -1,7 +1,10 @@
+import fs, { read, readFileSync } from 'fs';
+import { join } from 'path';
 import { json as jsonBodyParser } from 'body-parser';
 import cors from 'cors';
 import express from 'express';
 import type { Express } from 'express';
+import { validGithubTeams } from './validGithubTeams';
 
 export function buildApp(): Express {
 	const app = express();
@@ -19,9 +22,79 @@ export function buildApp(): Express {
 		res.status(200).json({ status: 'OK', stage: 'INFRA' });
 	});
 
-	app.get('/repos', (req: express.Request, res: express.Response) => {
-		res.status(200).json({});
-	});
+	const localJsonFilesCreatedFileName = join(
+		__dirname,
+		'../../../test/localJsonFilesCreated',
+	);
+
+	if (fs.existsSync(localJsonFilesCreatedFileName)) {
+		app.get('/', (req: express.Request, res: express.Response) => {
+			res.status(200).json([
+				{
+					endpoint: 'healthcheck',
+					info: 'check if API is responding',
+					testlink: 'http://localhost:3232/healthcheck',
+				},
+				{
+					endpoint: 'validGithubTeams',
+					info: 'all valid github teams',
+					testlink: 'http://localhost:3232/validGithubTeams',
+				},
+				{
+					endpoint: 'repos',
+					info: 'all Guardian repos',
+					testlink: 'http://localhost:3232/repos',
+				},
+				{
+					endpoint: 'reposAndOwnersDev',
+					info: 'all devX repos',
+					testlink: 'http://localhost:3232/reposAndOwnersDev',
+				},
+				{
+					endpoint: 'riffraff',
+					info: 'info about riffraff repo',
+					testlink: 'http://localhost:3232/riffraff',
+				},
+			]);
+		});
+
+		const repos = readFileSync(
+			join(__dirname, '../../../test/repos.json'),
+			'utf8',
+		);
+
+		app.get('/repos', (req: express.Request, res: express.Response) => {
+			res.status(200).json(JSON.parse(repos));
+		});
+
+		const reposAndOwnersDev = readFileSync(
+			join(__dirname, '../../../test/reposAndOwnersDev.json'),
+			'utf8',
+		);
+
+		app.get(
+			'/reposAndOwnersDev',
+			(req: express.Request, res: express.Response) => {
+				res.status(200).json(JSON.parse(reposAndOwnersDev));
+			},
+		);
+
+		app.get(
+			'/validGithubTeams',
+			(req: express.Request, res: express.Response) => {
+				res.status(200).json(validGithubTeams);
+			},
+		);
+
+		const riffraff = readFileSync(
+			join(__dirname, '../../../test/repoRiffRaff.json'),
+			'utf8',
+		);
+
+		app.get('/riffraff', (req: express.Request, res: express.Response) => {
+			res.status(200).json(JSON.parse(riffraff));
+		});
+	}
 
 	return app;
 }

--- a/packages/github-lens-api/src/app.ts
+++ b/packages/github-lens-api/src/app.ts
@@ -55,6 +55,24 @@ export function buildApp(): Express {
 					info: 'info about riffraff repo',
 					testlink: 'http://localhost:3232/riffraff',
 				},
+				// https://galaxies.gutools.co.uk/data/people.json
+				// https://galaxies.gutools.co.uk/data/teams.json
+				// https://galaxies.gutools.co.uk/data/streams.json
+				{
+					endpoint: 'people',
+					info: 'galaxies info about people',
+					testlink: 'http://localhost:3232/people',
+				},
+				{
+					endpoint: 'stream',
+					info: 'galaxies info about streams',
+					testlink: 'http://localhost:3232/stream',
+				},
+				{
+					endpoint: 'teams',
+					info: 'galaxies info about teamss',
+					testlink: 'http://localhost:3232/teams',
+				},
 			]);
 		});
 
@@ -93,6 +111,33 @@ export function buildApp(): Express {
 
 		app.get('/riffraff', (req: express.Request, res: express.Response) => {
 			res.status(200).json(JSON.parse(riffraff));
+		});
+
+		const people = readFileSync(
+			join(__dirname, '../../../test/people.json'),
+			'utf8',
+		);
+
+		app.get('/people', (req: express.Request, res: express.Response) => {
+			res.status(200).json(JSON.parse(people));
+		});
+
+		const teams = readFileSync(
+			join(__dirname, '../../../test/teams.json'),
+			'utf8',
+		);
+
+		app.get('/teams', (req: express.Request, res: express.Response) => {
+			res.status(200).json(JSON.parse(teams));
+		});
+
+		const streams = readFileSync(
+			join(__dirname, '../../../test/streams.json'),
+			'utf8',
+		);
+
+		app.get('/streams', (req: express.Request, res: express.Response) => {
+			res.status(200).json(JSON.parse(streams));
 		});
 	}
 

--- a/packages/github-lens-api/src/app.ts
+++ b/packages/github-lens-api/src/app.ts
@@ -66,11 +66,11 @@ export function buildApp(): Express {
 				{
 					endpoint: 'stream',
 					info: 'galaxies info about streams',
-					testlink: 'http://localhost:3232/stream',
+					testlink: 'http://localhost:3232/streams',
 				},
 				{
 					endpoint: 'teams',
-					info: 'galaxies info about teamss',
+					info: 'galaxies info about teams',
 					testlink: 'http://localhost:3232/teams',
 				},
 			]);

--- a/packages/repo-fetcher/src/handler.ts
+++ b/packages/repo-fetcher/src/handler.ts
@@ -1,3 +1,5 @@
+import { exists, readFileSync, writeFileSync } from 'fs';
+import * as fs from 'fs';
 import { join } from 'path';
 import type { Octokit } from '@octokit/rest';
 import { putItem } from '../../common/aws/s3';
@@ -7,8 +9,12 @@ import type {
 	TeamRepoResponse,
 } from '../../common/github/github';
 import {
+	getInfoForRepo,
 	getOctokit,
+	getRepos,
 	getReposForTeam,
+	getTeamBySlug,
+	getTeams,
 	listRepositories,
 	listTeams,
 } from '../../common/github/github';
@@ -20,14 +26,28 @@ import {
 	transformRepo,
 } from './transformations';
 
-const save = (
+const saveToS3 = (
 	dataKeyPrefix: string,
 	dataBucketName: string | undefined,
 	repos: Repository[],
+	fileName: string,
 ): Promise<void> => {
-	const key = join(dataKeyPrefix, 'github', 'repos.json');
-
+	const key = join(dataKeyPrefix, 'github', fileName);
 	return putItem(key, repos, dataBucketName);
+};
+
+const saveToTestDir = async (
+	client: Octokit,
+	stage: string,
+	fileName: string,
+	data: object,
+): Promise<void> => {
+	if (stage === 'DEV' && !fs.existsSync(fileName)) {
+		const repoRiffRaff = await getInfoForRepo(client, 'guardian', 'riff-raff');
+		writeFileSync(fileName, JSON.stringify(data), {
+			flag: 'w',
+		});
+	}
 };
 
 const createOwnerObjects = async (
@@ -44,23 +64,102 @@ export const main = async (): Promise<void> => {
 
 	const config = await getConfig();
 	const client = getOctokit(config);
-	const teamNames = await listTeams(client);
+
+	const stage = config.stage;
+	console.log(`[INFO] stage is ${stage}`);
+
+	console.log(`[INFO] running ListTeams`);
+	//teamNames array of teamNames
+	const teamNames = await getTeams(config.stage, client);
+	const teamNamesFileName = join(__dirname, '../../../test/teamNames.json');
+	if (stage === 'DEV' && !fs.existsSync(teamNamesFileName)) {
+		const repoRiffRaff = await getInfoForRepo(client, 'guardian', 'riff-raff');
+		writeFileSync(teamNamesFileName, JSON.stringify(teamNames), {
+			flag: 'w',
+		});
+	}
+	//single team
+	const devxTeam = await getTeamBySlug(client, 'devx-operations');
+	//const devxTeamSlug = devxTeam.data.slug;
+	const devxTeamSlug = 'devx-operations';
+	const repoRiffRaffFileName = join(
+		__dirname,
+		'../../../test/repoRiffRaff.json',
+	);
+	if (stage === 'DEV' && !fs.existsSync(repoRiffRaffFileName)) {
+		const repoRiffRaff = await getInfoForRepo(client, 'guardian', 'riff-raff');
+		writeFileSync(repoRiffRaffFileName, JSON.stringify(repoRiffRaff), {
+			flag: 'w',
+		});
+	}
 
 	console.log(`[INFO] found ${teamNames.length} github teams`);
+	console.log(`[INFO] running createOwnerObjects`);
+
+	const reposAndOwnersFileName = join(
+		__dirname,
+		'../../../test/reposAndOwnersDev.json',
+	);
+	if (stage === 'DEV' && !fs.existsSync(reposAndOwnersFileName)) {
+		const reposAndOwnersDev: RepoAndOwner[] = await createOwnerObjects(
+			client,
+			devxTeamSlug,
+		);
+		writeFileSync(reposAndOwnersFileName, JSON.stringify(reposAndOwnersDev), {
+			flag: 'w',
+		});
+	}
 
 	const reposAndOwners: RepoAndOwner[] = (
 		await Promise.all(
 			teamNames.map((team) => createOwnerObjects(client, team.slug)),
 		)
 	).flat();
+	console.log(`[INFO] createOwnerObjects done`);
 
-	const reposResponse: RepositoriesResponse = await listRepositories(client);
+	//getting all repos for the guardian takes a long time, so get less on DEV
+	const reposResponse: RepositoriesResponse = await getRepos(
+		config.stage,
+		client,
+	);
+
+	console.log(`[INFO] running transformRepo`);
 	const repos = reposResponse.map((response) =>
 		transformRepo(response, findOwnersOfRepo(response.name, reposAndOwners)),
 	);
-	await save(config.dataKeyPrefix, config.dataBucketName, repos);
+	console.log(`[INFO] transformRepo done`);
+
+	console.log(`[INFO] saving to bucket`);
+	if (stage === 'DEV') {
+		writeFileSync(
+			join(__dirname, '../../../test/repos.json'),
+			JSON.stringify(repos),
+			{
+				flag: 'w',
+			},
+		);
+	} else {
+		await saveToS3(
+			config.dataKeyPrefix,
+			config.dataBucketName,
+			repos,
+			'repos.json',
+		);
+	}
+	console.log(`[INFO] save to bucket done`);
 
 	console.log(`[INFO] found ${repos.length} repos`);
+
+	if (stage === 'DEV') {
+		writeFileSync(
+			join(__dirname, '../../../test/localJsonFilesCreated'),
+			JSON.stringify('created local json files for easy of testing'),
+			{
+				flag: 'w',
+			},
+		);
+	}
+
 	console.log(`[INFO] finishing repo-fetcher`);
 };
 

--- a/test/README
+++ b/test/README
@@ -1,0 +1,1 @@
+test directory of json files


### PR DESCRIPTION
## What does this change?

As a starting point the api now serves some endpoint on dev after running fetch.
For new the output is stored in the local directory test.
Kenny suggested moving this to a local S3, but as far as I know the current discussion point is to move the whole repo fetcher into tracker

## How to test

To fetch the data you need to run:

```
# Fetches data from GitHub
npm -w packages/repo-fetcher run dev

# Start the API locally
npm -w packages/github-lens-api run dev
```
This will start the api on localhost:3232
Running localhost will show the current endpoints
(both commands are provided in package.json as fetch and localapi)
