### PR TITLE
Add Localstack S3 interaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.zip
 .idea
+.localstack
 .DS_Store
 data
 node_modules

--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ The setup script will download a starter `.env`.
 
 ### Running locally
 
+In order to simulate S3 locally and allow the repo-fetcher lambda and github-lens API to share data, we use [localstack](https://github.com/localstack/localstack). 
+
+Start `localstack` by running:
+
+```
+docker-compose up
+```
+
+You will now be able to interact with local S3 by referring to the local S3 endpoint:
+
+```
+aws --endpoint-url=http://localhost:4566 s3 ls s3://data-bucket
+```
+
 The project uses npm workspaces, and individual workspaces should have a `dev` script that can be run to execute e.g.
 ```
 npm -w packages/repo-fetcher run dev

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+    localstack:
+      container_name: localstack-aws
+      image: localstack/localstack
+      ports:
+        - "4566:4566" # Default port forward
+        - "${PORT_WEB_UI-8181}:${PORT_WEB_UI-8181}"       
+      environment:
+        - SERVICES=s3 #AWS Services that you want in your localstack
+        - DEBUG=1 # Debug level 1 if you want to logs, 0 if you want to disable
+        - START_WEB=0 # Flag to control whether the Web UI should be started in Docker
+        - LAMBDA_REMOTE_DOCKER=0
+        - DATA_DIR=/var/lib/localstack #  Local directory for saving persistent data(Example: es storage)
+        - DEFAULT_REGION=eu-west-1
+      volumes:
+        - './.localstack:/tmp/localstack'
+        - '/var/run/docker.sock:/var/run/docker.sock'
+        - ./scripts/localstack:/docker-entrypoint-initaws.d

--- a/packages/common/config.ts
+++ b/packages/common/config.ts
@@ -11,8 +11,10 @@ export type Config = {
 		appPrivateKey: string;
 		appInstallationId: string;
 	};
-	dataBucketName: string | undefined;
+	bucketName: string;
 	stage: Stage;
+	region: string;
+	endpoint: string | undefined;
 };
 
 export const mandatoryEncrypted = async (
@@ -45,6 +47,8 @@ export const optional = (item: string): string | undefined => process.env[item];
 export const optionalWithDefault = (item: string, _default: string): string =>
 	optional(item) ?? _default;
 
+export const stage = optionalWithDefault('STAGE', 'DEV') as Stage;
+
 export const getConfig = async (): Promise<Config> => {
 	const configDecryptionKeyId = mandatory('KMS_KEY_ID');
 	const appPrivateKey = await mandatoryEncrypted(
@@ -52,6 +56,8 @@ export const getConfig = async (): Promise<Config> => {
 		configDecryptionKeyId,
 	);
 	const stage = optionalWithDefault('STAGE', 'DEV') as Stage;
+	const region = optionalWithDefault('AWS_REGION', 'eu-west-1');
+	const endpoint = stage === 'DEV' ? 'http://localhost:4566/' : undefined;
 
 	return {
 		github: {
@@ -59,8 +65,10 @@ export const getConfig = async (): Promise<Config> => {
 			appPrivateKey: appPrivateKey,
 			appInstallationId: mandatory('GITHUB_APP_INSTALLATION_ID'),
 		},
-		dataBucketName: optional('DATA_BUCKET_NAME'),
+		bucketName: optionalWithDefault('DATA_BUCKET_NAME', 'data-bucket'),
 		dataKeyPrefix: optionalWithDefault('DATA_KEY_PREFIX', stage),
 		stage,
+		region,
+		endpoint,
 	};
 };

--- a/scripts/localstack/buckets.sh
+++ b/scripts/localstack/buckets.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -x
+awslocal s3 mb s3://data-bucket
+set +x


### PR DESCRIPTION
## What does this change?

This change adds `localstack` configuration to allow the `repo-fetcher` lambda to store data in a local S3 instance, allowing the `github-lens` api lambda to also access this local data for ease of development.

It's also possible to interact with the local S3 instance to download and review any data the application uploads.

This change could be an improvement over internalising the caching logic within the application as it:

- Reduces the complexity of the application code making it easier to understand, work with & maintain.
- Developers working with `localstack` are presented with an experience closer to dealing with AWS APIs

It does require developers to be familiar with and use `docker-compose` in so far as it should be installed and there should be an easy way of starting it, but this should not be onerous compared to carrying the logic in the application going forward.