### PR TITLE
Use configured bucket from environment locally

### DIFF
--- a/packages/cdk/lib/__snapshots__/github-lens.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/github-lens.test.ts.snap
@@ -865,6 +865,7 @@ Object {
     "githublensdatabucketGithublens7C07FDE7": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
+        "BucketName": "github-lens-data-infra",
         "PublicAccessBlockConfiguration": Object {
           "BlockPublicAcls": true,
           "BlockPublicPolicy": true,

--- a/packages/cdk/lib/github-lens.ts
+++ b/packages/cdk/lib/github-lens.ts
@@ -23,6 +23,7 @@ export class GithubLens extends GuStack {
 		const app = 'github-lens';
 
 		const dataBucket = new GuS3Bucket(this, `${app}-data-bucket`, {
+			bucketName: `github-lens-data-${this.stage.toLowerCase()}`,
 			app,
 		});
 

--- a/packages/common/aws/s3.ts
+++ b/packages/common/aws/s3.ts
@@ -1,34 +1,35 @@
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 
-export class S3Ops {
-	private readonly s3Client: S3Client;
+export const getS3Client = (region: string): S3Client => {
+	return new S3Client({
+		region,
+	});
+};
 
-	constructor(region: string) {
-		this.s3Client = new S3Client({
-			region,
+export const putObject = async <T>(
+	s3Client: S3Client,
+	bucketName: string,
+	key: string,
+	body: T,
+): Promise<void> => {
+	try {
+		const command = new PutObjectCommand({
+			Bucket: bucketName,
+			Key: key,
+			Body: JSON.stringify(body),
+			ContentType: 'application/json; charset=utf-8',
+			ACL: 'private',
 		});
-	}
 
-	async putObject<T>(bucketName: string, key: string, body: T): Promise<void> {
-		try {
-			const command = new PutObjectCommand({
-				Bucket: bucketName,
-				Key: key,
-				Body: JSON.stringify(body),
-				ContentType: 'application/json; charset=utf-8',
-				ACL: 'private',
-			});
-
-			await this.s3Client.send(command);
-			console.log(
-				`Item uploaded to s3 successfully to: s3://${bucketName}/${key}`,
-			);
-		} catch (e) {
-			if (e instanceof Error) {
-				console.error(`Error uploading item to s3: ${e.message}`);
-			} else {
-				console.error(e);
-			}
+		await s3Client.send(command);
+		console.log(
+			`Item uploaded to s3 successfully to: s3://${bucketName}/${key}`,
+		);
+	} catch (e) {
+		if (e instanceof Error) {
+			console.error(`Error uploading item to s3: ${e.message}`);
+		} else {
+			console.error(e);
 		}
 	}
-}
+};

--- a/packages/common/aws/s3.ts
+++ b/packages/common/aws/s3.ts
@@ -1,32 +1,34 @@
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 
-const region = 'eu-west-1';
-const s3Client = new S3Client({
-	region,
-});
+export class S3Ops {
+	private readonly s3Client: S3Client;
 
-export const putItem = async <T>(
-	key: string,
-	body: T,
-	dataBucketName: string | undefined,
-): Promise<void> => {
-	if (dataBucketName) {
-		const command = new PutObjectCommand({
-			Bucket: dataBucketName,
-			Key: key,
-			Body: JSON.stringify(body),
-			ContentType: 'application/json; charset=utf-8',
-			ACL: 'private',
+	constructor(region: string) {
+		this.s3Client = new S3Client({
+			region,
 		});
+	}
+
+	async putObject<T>(bucketName: string, key: string, body: T): Promise<void> {
 		try {
-			await s3Client.send(command);
+			const command = new PutObjectCommand({
+				Bucket: bucketName,
+				Key: key,
+				Body: JSON.stringify(body),
+				ContentType: 'application/json; charset=utf-8',
+				ACL: 'private',
+			});
+
+			await this.s3Client.send(command);
 			console.log(
-				`Item uploaded to s3 successfully to: s3://${dataBucketName}/${key}`,
+				`Item uploaded to s3 successfully to: s3://${bucketName}/${key}`,
 			);
 		} catch (e) {
-			console.error(`${(e as Error).message}`);
+			if (e instanceof Error) {
+				console.error(`Error uploading item to s3: ${e.message}`);
+			} else {
+				console.error(e);
+			}
 		}
-	} else {
-		console.warn('No data bucket configured, skipping putItem');
 	}
-};
+}

--- a/packages/common/config.ts
+++ b/packages/common/config.ts
@@ -11,7 +11,8 @@ export type Config = {
 		appPrivateKey: string;
 		appInstallationId: string;
 	};
-	dataBucketName: string | undefined;
+	dataBucketName: string;
+	region: string;
 	stage: Stage;
 };
 
@@ -59,8 +60,9 @@ export const getConfig = async (): Promise<Config> => {
 			appPrivateKey: appPrivateKey,
 			appInstallationId: mandatory('GITHUB_APP_INSTALLATION_ID'),
 		},
-		dataBucketName: optional('DATA_BUCKET_NAME'),
+		dataBucketName: mandatory('DATA_BUCKET_NAME'),
 		dataKeyPrefix: optionalWithDefault('DATA_KEY_PREFIX', stage),
+		region: optionalWithDefault('AWS_REGION', 'eu-west-1'),
 		stage,
 	};
 };

--- a/packages/repo-fetcher/src/handler.ts
+++ b/packages/repo-fetcher/src/handler.ts
@@ -1,6 +1,5 @@
-import { join } from 'path';
 import type { Octokit } from '@octokit/rest';
-import { S3Ops } from '../../common/aws/s3';
+import { getS3Client, putObject } from '../../common/aws/s3';
 import { getConfig } from '../../common/config';
 import type {
 	RepositoriesResponse,
@@ -38,7 +37,7 @@ export const main = async (): Promise<void> => {
 	const client = getOctokit(config);
 	const teamNames = await listTeams(client);
 
-	const s3Ops = new S3Ops(config.region);
+	const s3Client = getS3Client(config.region);
 
 	console.log(`Found ${teamNames.length} github teams`);
 
@@ -53,7 +52,7 @@ export const main = async (): Promise<void> => {
 		transformRepo(response, findOwnersOfRepo(response.name, reposAndOwners)),
 	);
 
-	await s3Ops.putObject(config.dataBucketName, config.dataKeyPrefix, repos);
+	await putObject(s3Client, config.dataBucketName, config.dataKeyPrefix, repos);
 
 	console.log(`Found ${repos.length} repos`);
 	console.log(`Finishing repo-fetcher`);


### PR DESCRIPTION
## What does this change?

This change is intended to improve the DX of this repository by allowing the lambda running locally to use the INFRA stack S3 bucket with the "DEV" prefix. It makes specifying a bucket name mandatory and expects this to be made available in a local `.env` file as follows:

```
DATA_BUCKET_NAME=github-lens-data-INFRA
```

There is only an INFRA stack for this application and the value of `DATA_BUCKET_NAME` should be that in the currently created stack.

Note: When this is deployed and a stack is created next we'll need to update the .env file in S3 to reference the S3 bucket created in the INFRA stack.