### PR TITLE
Remove reference to Team Fetcher as it doesn't exist!

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ The project consists of the following subprojects:
 
 - **Repo Fetcher**: A fetcher for repository metadata
 
-- **Teams Fetcher**: A fetcher for teams metadata
-
 ## Local Development
 
 If this your first time developing github-lens, you should run:


### PR DESCRIPTION
## What does this change?

Tiny docs update to reflect that team fetcher doesn't exist.