### PR TITLE
Make API private

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
+      - uses: guardian/actions-read-private-repos@v0.1.0
+        with:
+          private-ssh-keys: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
+
       - name: Run script/ci
         run: ./scripts/ci.sh
 

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -9,5 +9,5 @@ new GithubLens(app, 'GithubLens-INFRA', {
 	stage: 'INFRA',
 	env: { region: 'eu-west-1' },
 	domainName: 'github-lens.gutools.co.uk',
-	vpceId: 'vpce-0cb20360ab01108de',
+	vpceId: 'vpce-04f40fb1a4a0a23a6',
 });

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -9,4 +9,5 @@ new GithubLens(app, 'GithubLens-INFRA', {
 	stage: 'INFRA',
 	env: { region: 'eu-west-1' },
 	domainName: 'github-lens.gutools.co.uk',
+	vpceId: 'vpce-0cb20360ab01108de',
 });

--- a/packages/cdk/lib/__snapshots__/github-lens.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/github-lens.test.ts.snap
@@ -76,7 +76,6 @@ Object {
             "Fn::Join": Array [
               "",
               Array [
-                "https://",
                 Object {
                   "Ref": "githublensapilambdagithublensFC5CBB44",
                 },

--- a/packages/cdk/lib/__snapshots__/github-lens.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/github-lens.test.ts.snap
@@ -89,7 +89,7 @@ Object {
           },
         ],
         "Stage": "INFRA",
-        "TTL": 86400,
+        "TTL": 3600,
       },
       "Type": "Guardian::DNS::RecordSet",
     },

--- a/packages/cdk/lib/__snapshots__/github-lens.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/github-lens.test.ts.snap
@@ -10,7 +10,6 @@ Object {
       "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuApiLambda",
-      "GuCertificate",
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm",
     ],
@@ -68,46 +67,25 @@ Object {
     },
   },
   "Resources": Object {
-    "CertificateGithublens25494A00": Object {
-      "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "DomainName": "github-lens.gutools.co.uk",
-        "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "github-lens",
-          },
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/github-lens",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": "INFRA",
-          },
-        ],
-        "ValidationMethod": "DNS",
-      },
-      "Type": "AWS::CertificateManager::Certificate",
-      "UpdateReplacePolicy": "Retain",
-    },
     "DNS": Object {
       "Properties": Object {
         "Name": "github-lens.gutools.co.uk",
         "RecordType": "CNAME",
         "ResourceRecords": Array [
           Object {
-            "Fn::GetAtt": Array [
-              "githublensapilambdagithublensdomainAF6EC35F",
-              "RegionalDomainName",
+            "Fn::Join": Array [
+              "",
+              Array [
+                "https://",
+                Object {
+                  "Ref": "githublensapilambdagithublensFC5CBB44",
+                },
+                "-PLACEHOLDER.execute-api.",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ".amazonaws.com",
+              ],
             ],
           },
         ],
@@ -168,6 +146,32 @@ Object {
         ],
       },
       "Type": "AWS::KMS::Key",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ProdLogsCA1A5D7E": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "RetentionInDays": 14,
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/github-lens",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "INFRA",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
     "githublensapilambda36E7A473": Object {
@@ -599,7 +603,7 @@ Object {
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "githublensapilambdagithublensDeploymentF3C58D95e46845091e43c98251412ef4837752d2": Object {
+    "githublensapilambdagithublensDeploymentF3C58D95423b4ed1c982787941c175b5afa76a10": Object {
       "DependsOn": Array [
         "githublensapilambdagithublensproxyANYFD25689D",
         "githublensapilambdagithublensproxy306AC689",
@@ -618,8 +622,17 @@ Object {
         "githublensapilambdagithublensAccount21DDF10C",
       ],
       "Properties": Object {
+        "AccessLogSetting": Object {
+          "DestinationArn": Object {
+            "Fn::GetAtt": Array [
+              "ProdLogsCA1A5D7E",
+              "Arn",
+            ],
+          },
+          "Format": "{\\"requestId\\":\\"$context.requestId\\",\\"ip\\":\\"$context.identity.sourceIp\\",\\"user\\":\\"$context.identity.user\\",\\"caller\\":\\"$context.identity.caller\\",\\"requestTime\\":\\"$context.requestTime\\",\\"httpMethod\\":\\"$context.httpMethod\\",\\"resourcePath\\":\\"$context.resourcePath\\",\\"status\\":\\"$context.status\\",\\"protocol\\":\\"$context.protocol\\",\\"responseLength\\":\\"$context.responseLength\\"}",
+        },
         "DeploymentId": Object {
-          "Ref": "githublensapilambdagithublensDeploymentF3C58D95e46845091e43c98251412ef4837752d2",
+          "Ref": "githublensapilambdagithublensDeploymentF3C58D95423b4ed1c982787941c175b5afa76a10",
         },
         "RestApiId": Object {
           "Ref": "githublensapilambdagithublensFC5CBB44",
@@ -653,7 +666,32 @@ Object {
     "githublensapilambdagithublensFC5CBB44": Object {
       "Properties": Object {
         "Description": "API that proxies all requests to Lambda",
+        "DisableExecuteApiEndpoint": false,
+        "EndpointConfiguration": Object {
+          "Types": Array [
+            "PRIVATE",
+          ],
+          "VpcEndpointIds": Array [
+            "PLACEHOLDER",
+          ],
+        },
         "Name": "deploy-INFRA-github-lens",
+        "Policy": Object {
+          "Statement": Array [
+            Object {
+              "Action": "execute-api:Invoke",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "aws:SourceVpce": "PLACEHOLDER",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": "execute-api:/*/*/*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
         "Tags": Array [
           Object {
             "Key": "App",
@@ -678,56 +716,6 @@ Object {
         ],
       },
       "Type": "AWS::ApiGateway::RestApi",
-    },
-    "githublensapilambdagithublensdomainAF6EC35F": Object {
-      "Properties": Object {
-        "DomainName": "github-lens.gutools.co.uk",
-        "EndpointConfiguration": Object {
-          "Types": Array [
-            "REGIONAL",
-          ],
-        },
-        "RegionalCertificateArn": Object {
-          "Ref": "CertificateGithublens25494A00",
-        },
-        "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "github-lens-api",
-          },
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/github-lens",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": "INFRA",
-          },
-        ],
-      },
-      "Type": "AWS::ApiGateway::DomainName",
-    },
-    "githublensapilambdagithublensdomainMapGithubLensgithublensapilambdagithublens0420DDC236C3D399": Object {
-      "Properties": Object {
-        "DomainName": Object {
-          "Ref": "githublensapilambdagithublensdomainAF6EC35F",
-        },
-        "RestApiId": Object {
-          "Ref": "githublensapilambdagithublensFC5CBB44",
-        },
-        "Stage": Object {
-          "Ref": "githublensapilambdagithublensDeploymentStageprod05B08EE8",
-        },
-      },
-      "Type": "AWS::ApiGateway::BasePathMapping",
     },
     "githublensapilambdagithublensproxy306AC689": Object {
       "Properties": Object {

--- a/packages/cdk/lib/github-lens.test.ts
+++ b/packages/cdk/lib/github-lens.test.ts
@@ -9,6 +9,7 @@ describe('The GithubLens stack', () => {
 			stack: 'deploy',
 			stage: 'INFRA',
 			domainName: 'github-lens.gutools.co.uk',
+			vpceId: 'PLACEHOLDER',
 		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();

--- a/packages/cdk/lib/github-lens.ts
+++ b/packages/cdk/lib/github-lens.ts
@@ -135,7 +135,7 @@ export class GithubLens extends GuStack {
 
 		new GuCname(this, 'DNS', {
 			app: app,
-			ttl: Duration.days(1),
+			ttl: Duration.hours(1),
 			domainName: props.domainName,
 			// See: https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-api-test-invoke-url.html#apigateway-private-api-public-dns.
 			resourceRecord: `${apiLambda.api.restApiId}-${props.vpceId}.execute-api.${this.region}.amazonaws.com`,

--- a/packages/cdk/lib/github-lens.ts
+++ b/packages/cdk/lib/github-lens.ts
@@ -1,5 +1,4 @@
 import { GuApiLambda, GuScheduledLambda } from '@guardian/cdk';
-import { GuCertificate } from '@guardian/cdk/lib/constructs/acm';
 import type { NoMonitoring } from '@guardian/cdk/lib/constructs/cloudwatch';
 import { GuStack, GuStringParameter } from '@guardian/cdk/lib/constructs/core';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
@@ -7,13 +6,31 @@ import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import type { App } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
+import {
+	AccessLogFormat,
+	EndpointType,
+	LogGroupLogDestination,
+} from 'aws-cdk-lib/aws-apigateway';
+import { InterfaceVpcEndpoint } from 'aws-cdk-lib/aws-ec2';
 import { Schedule } from 'aws-cdk-lib/aws-events';
-import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import {
+	Effect,
+	PolicyDocument,
+	PolicyStatement,
+	StarPrincipal,
+} from 'aws-cdk-lib/aws-iam';
 import { Key } from 'aws-cdk-lib/aws-kms';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { LogGroup } from 'aws-cdk-lib/aws-logs';
 
 interface GithubLensProps extends GuStackProps {
+	// Domain name to use for the app/stage.
 	domainName: string;
+
+	// ID of a virtual private endpoint used to connect to this private API
+	// Gateway. For more info, see:
+	// https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-apis.html#apigateway-private-api-create-interface-vpc-endpoint.
+	vpceId: string;
 }
 
 export class GithubLens extends GuStack {
@@ -70,6 +87,10 @@ export class GithubLens extends GuStack {
 
 		const noMonitoring: NoMonitoring = { noMonitoring: true };
 
+		const prodLogGroup = new LogGroup(this, 'ProdLogs', {
+			retention: 14,
+		});
+
 		const apiLambda = new GuApiLambda(this, `${apiApp}-lambda`, {
 			fileName: `${apiApp}.zip`,
 			handler: 'handler.main',
@@ -78,23 +99,46 @@ export class GithubLens extends GuStack {
 			app: apiApp,
 			api: {
 				id: 'github-lens',
+				deployOptions: {
+					accessLogDestination: new LogGroupLogDestination(prodLogGroup),
+					accessLogFormat: AccessLogFormat.jsonWithStandardFields(),
+				},
 				description: 'API that proxies all requests to Lambda',
+				endpointConfiguration: {
+					types: [EndpointType.PRIVATE],
+					vpcEndpoints: [
+						InterfaceVpcEndpoint.fromInterfaceVpcEndpointAttributes(
+							this,
+							'vpce',
+							{ vpcEndpointId: props.vpceId, port: 443 },
+						),
+					],
+				},
+				disableExecuteApiEndpoint: false,
+				policy: new PolicyDocument({
+					statements: [
+						new PolicyStatement({
+							actions: ['execute-api:Invoke'],
+							principals: [new StarPrincipal()],
+							resources: ['execute-api:/*/*/*'],
+							effect: Effect.ALLOW,
+							conditions: {
+								StringEquals: {
+									'aws:SourceVpce': props.vpceId,
+								},
+							},
+						}),
+					],
+				}),
 			},
-		});
-
-		const domain = apiLambda.api.addDomainName('domain', {
-			domainName: props.domainName,
-			certificate: new GuCertificate(this, {
-				app: app,
-				domainName: props.domainName,
-			}),
 		});
 
 		new GuCname(this, 'DNS', {
 			app: app,
 			ttl: Duration.days(1),
 			domainName: props.domainName,
-			resourceRecord: domain.domainNameAliasDomainName,
+			// See: https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-api-test-invoke-url.html#apigateway-private-api-public-dns.
+			resourceRecord: `https://${apiLambda.api.restApiId}-${props.vpceId}.execute-api.${this.region}.amazonaws.com`,
 		});
 
 		const scheduledLambda = new GuScheduledLambda(

--- a/packages/cdk/lib/github-lens.ts
+++ b/packages/cdk/lib/github-lens.ts
@@ -138,7 +138,7 @@ export class GithubLens extends GuStack {
 			ttl: Duration.days(1),
 			domainName: props.domainName,
 			// See: https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-api-test-invoke-url.html#apigateway-private-api-public-dns.
-			resourceRecord: `https://${apiLambda.api.restApiId}-${props.vpceId}.execute-api.${this.region}.amazonaws.com`,
+			resourceRecord: `${apiLambda.api.restApiId}-${props.vpceId}.execute-api.${this.region}.amazonaws.com`,
 		});
 
 		const scheduledLambda = new GuScheduledLambda(


### PR DESCRIPTION
API Gateway supports private endpoints that can be accessed from within a VPC. See:

https://aws.amazon.com/blogs/compute/introducing-amazon-api-gateway-private-endpoints/

We'll use this to limit access to other services and also ourselves (requires being on the VPN).

See also: https://github.com/guardian/deploy-tools-platform/pull/623.

Update, this now works. It required some changes to the resource policy and also the domain handling. The API itself needs to be private, and have the default API endpoint enabled - as it is used by the VPC endpoint.

Depends on https://github.com/guardian/deploy-tools-platform/pull/623.

*Note: https://docs.aws.amazon.com/vpc/latest/reachability/what-is-reachability-analyzer.html was incredibly useful in debugging some of the networking issues here. https://aws.amazon.com/premiumsupport/knowledge-center/api-gateway-troubleshoot-403-forbidden/ was another useful resource here.*

Co-authored-by: Natasha Thrale <novembertang@users.noreply.github.com>
