### PR TITLE
feat: Allow collection of data for one GH team

### DIFF
--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -1,7 +1,7 @@
 import * as dotenv from 'dotenv';
 import { decrypt } from './aws/kms';
 
-dotenv.config({ path: `${__dirname}/../../.env` });
+dotenv.config({ path: `${__dirname}/../../../.env` });
 
 export type Stage = 'PROD' | 'CODE' | 'DEV';
 

--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -19,6 +19,7 @@ export type GitHubConfig = {
 	appId: string;
 	appPrivateKey: string;
 	appInstallationId: string;
+	teamToFetch?: string;
 };
 
 const octokit = new Octokit();

--- a/packages/repo-fetcher/src/config.ts
+++ b/packages/repo-fetcher/src/config.ts
@@ -31,6 +31,7 @@ export const getConfig = async (): Promise<Config> => {
 			appId: mandatory('GITHUB_APP_ID'),
 			appPrivateKey: appPrivateKey,
 			appInstallationId: mandatory('GITHUB_APP_INSTALLATION_ID'),
+			teamToFetch: optional('GITHUB_TEAM'),
 		},
 		dataBucketName: mandatory('DATA_BUCKET_NAME'),
 		dataKeyPrefix: optionalWithDefault('DATA_KEY_PREFIX', stage),

--- a/packages/repo-fetcher/src/handler.ts
+++ b/packages/repo-fetcher/src/handler.ts
@@ -14,13 +14,13 @@ import { asRepo, getAdminReposFromResponse } from './transformations';
 // Returns a map of repoName -> admins (a list of team slugs).
 const teamRepositories = async (
 	client: Octokit,
-	teams: TeamsResponse,
+	teamNames: string[],
 ): Promise<Record<string, string[] | undefined>> => {
-	const teamRepositories = teams.map(async (team) => {
-		const teamRepos = await getReposForTeam(client, team.slug);
+	const teamRepositories = teamNames.map(async (teamName) => {
+		const teamRepos = await getReposForTeam(client, teamName);
 		const adminRepos: string[] = getAdminReposFromResponse(teamRepos);
 		return adminRepos.map((repoName) => ({
-			teamSlug: team.slug,
+			teamSlug: teamName,
 			repoName,
 		}));
 	});
@@ -34,6 +34,18 @@ const teamRepositories = async (
 	}, {});
 };
 
+async function getTeamNames(
+	client: Octokit,
+	teamName?: string,
+): Promise<string[]> {
+	if (teamName) {
+		return Promise.resolve([teamName]);
+	}
+
+	const allTeams = await listTeams(client);
+	return allTeams.map((_) => _.slug);
+}
+
 export const main = async (): Promise<void> => {
 	const config = await getConfig();
 	configureLogging(getLogLevel(config.logLevel));
@@ -42,13 +54,13 @@ export const main = async (): Promise<void> => {
 
 	const client = getOctokit(config.github);
 
-	const teams = await listTeams(client);
-	console.log(`Found ${teams.length} github teams`);
+	const teamNames = await getTeamNames(client, config.github.teamToFetch);
+	console.log(`Found ${teamNames.length} github teams`);
 
 	const repositories = await listRepositories(client);
 	console.log(`Found ${repositories.length} github repos`);
 
-	const repositoriesToAdmins = await teamRepositories(client, teams);
+	const repositoriesToAdmins = await teamRepositories(client, teamNames);
 
 	const repos = repositories.map((repository) =>
 		asRepo(repository, repositoriesToAdmins[repository.name] ?? []),

--- a/packages/repo-fetcher/src/handler.ts
+++ b/packages/repo-fetcher/src/handler.ts
@@ -1,6 +1,5 @@
 import type { Octokit } from '@octokit/rest';
 import { getS3Client, putObject } from 'common/aws/s3';
-import type { TeamsResponse } from 'common/github/github';
 import {
 	getOctokit,
 	getReposForTeam,


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This project heavily relies on the GitHub API. This API is rate limited.

In an attempt to improve the local DX, in this change we add a new configuration property `GITHUB_TEAM`. When set, we reduce the amount of API calls made to hopefully yield a faster feedback loop when developing locally.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Checkout branch
- Set `GITHUB_TEAM` env var
- Run repo-fetcher
