### PR TITLE
Config in common package is specific to repo-fetcher

### DIFF
--- a/packages/common/config.ts
+++ b/packages/common/config.ts
@@ -1,23 +1,9 @@
 import * as dotenv from 'dotenv';
 import { decrypt } from './aws/kms';
-import { getLogLevel } from './log/log';
-import type { LogLevel } from './log/log';
 
 dotenv.config({ path: `${__dirname}/../../.env` });
 
 export type Stage = 'PROD' | 'CODE' | 'DEV';
-export type Config = {
-	dataKeyPrefix: string;
-	github: {
-		appId: string;
-		appPrivateKey: string;
-		appInstallationId: string;
-	};
-	dataBucketName: string;
-	region: string;
-	stage: Stage;
-	logLevel: LogLevel;
-};
 
 export const mandatoryEncrypted = async (
 	item: string,
@@ -48,25 +34,3 @@ export const mandatory = (item: string): string => {
 export const optional = (item: string): string | undefined => process.env[item];
 export const optionalWithDefault = (item: string, _default: string): string =>
 	optional(item) ?? _default;
-
-export const getConfig = async (): Promise<Config> => {
-	const configDecryptionKeyId = mandatory('KMS_KEY_ID');
-	const appPrivateKey = await mandatoryEncrypted(
-		'GITHUB_APP_PRIVATE_KEY',
-		configDecryptionKeyId,
-	);
-	const stage = optionalWithDefault('STAGE', 'DEV') as Stage;
-
-	return {
-		github: {
-			appId: mandatory('GITHUB_APP_ID'),
-			appPrivateKey: appPrivateKey,
-			appInstallationId: mandatory('GITHUB_APP_INSTALLATION_ID'),
-		},
-		dataBucketName: mandatory('DATA_BUCKET_NAME'),
-		dataKeyPrefix: optionalWithDefault('DATA_KEY_PREFIX', stage),
-		region: optionalWithDefault('AWS_REGION', 'eu-west-1'),
-		stage,
-		logLevel: getLogLevel(optional('LOG_LEVEL')),
-	};
-};

--- a/packages/common/github/github.ts
+++ b/packages/common/github/github.ts
@@ -2,7 +2,6 @@ import { createAppAuth } from '@octokit/auth-app';
 import { throttling } from '@octokit/plugin-throttling';
 import { Octokit } from '@octokit/rest';
 import type { GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
-import type { Config } from '../config';
 import { sleep } from '../sleep';
 
 const ThrottledOctokit = Octokit.plugin(throttling);
@@ -15,6 +14,12 @@ interface Options {
 		retryCount: number;
 	};
 }
+
+export type GitHubConfig = {
+	appId: string;
+	appPrivateKey: string;
+	appInstallationId: string;
+};
 
 const octokit = new Octokit();
 export type RepositoriesResponse = GetResponseDataTypeFromEndpointMethod<
@@ -30,19 +35,17 @@ export type RepositoryResponse = RepositoriesResponse[number];
 
 let _octokit: Octokit | undefined;
 
-export const getOctokit = (config: Config): Octokit => {
+export const getOctokit = (config: GitHubConfig): Octokit => {
 	if (_octokit) {
 		return _octokit;
 	}
 
-	const credentials = config.github;
-
 	_octokit = new ThrottledOctokit({
 		authStrategy: createAppAuth,
 		auth: {
-			appId: credentials.appId,
-			privateKey: credentials.appPrivateKey,
-			installationId: credentials.appInstallationId,
+			appId: config.appId,
+			privateKey: config.appPrivateKey,
+			installationId: config.appInstallationId,
 		},
 		throttle: {
 			onRateLimit: (retryAfter: number, options: Options) => {

--- a/packages/repo-fetcher/src/config.ts
+++ b/packages/repo-fetcher/src/config.ts
@@ -5,16 +5,13 @@ import {
 	optional,
 	optionalWithDefault,
 } from '../../common/config';
+import type { GitHubConfig } from '../../common/github/github';
 import { getLogLevel } from '../../common/log/log';
 import type { LogLevel } from '../../common/log/log';
 
 export type Config = {
 	dataKeyPrefix: string;
-	github: {
-		appId: string;
-		appPrivateKey: string;
-		appInstallationId: string;
-	};
+	github: GitHubConfig;
 	dataBucketName: string;
 	region: string;
 	stage: Stage;

--- a/packages/repo-fetcher/src/config.ts
+++ b/packages/repo-fetcher/src/config.ts
@@ -1,0 +1,44 @@
+import type { Stage } from '../../common/config';
+import {
+	mandatory,
+	mandatoryEncrypted,
+	optional,
+	optionalWithDefault,
+} from '../../common/config';
+import { getLogLevel } from '../../common/log/log';
+import type { LogLevel } from '../../common/log/log';
+
+export type Config = {
+	dataKeyPrefix: string;
+	github: {
+		appId: string;
+		appPrivateKey: string;
+		appInstallationId: string;
+	};
+	dataBucketName: string;
+	region: string;
+	stage: Stage;
+	logLevel: LogLevel;
+};
+
+export const getConfig = async (): Promise<Config> => {
+	const configDecryptionKeyId = mandatory('KMS_KEY_ID');
+	const appPrivateKey = await mandatoryEncrypted(
+		'GITHUB_APP_PRIVATE_KEY',
+		configDecryptionKeyId,
+	);
+	const stage = optionalWithDefault('STAGE', 'DEV') as Stage;
+
+	return {
+		github: {
+			appId: mandatory('GITHUB_APP_ID'),
+			appPrivateKey: appPrivateKey,
+			appInstallationId: mandatory('GITHUB_APP_INSTALLATION_ID'),
+		},
+		dataBucketName: mandatory('DATA_BUCKET_NAME'),
+		dataKeyPrefix: optionalWithDefault('DATA_KEY_PREFIX', stage),
+		region: optionalWithDefault('AWS_REGION', 'eu-west-1'),
+		stage,
+		logLevel: getLogLevel(optional('LOG_LEVEL')),
+	};
+};

--- a/packages/repo-fetcher/src/handler.ts
+++ b/packages/repo-fetcher/src/handler.ts
@@ -1,6 +1,5 @@
 import type { Octokit } from '@octokit/rest';
 import { getS3Client, putObject } from '../../common/aws/s3';
-import { getConfig } from '../../common/config';
 import type { TeamsResponse } from '../../common/github/github';
 import {
 	getOctokit,
@@ -9,6 +8,7 @@ import {
 	listTeams,
 } from '../../common/github/github';
 import { configureLogging, getLogLevel } from '../../common/log/log';
+import { getConfig } from './config';
 import { asRepo, getAdminReposFromResponse } from './transformations';
 
 // Returns a map of repoName -> admins (a list of team slugs).

--- a/packages/repo-fetcher/src/handler.ts
+++ b/packages/repo-fetcher/src/handler.ts
@@ -40,7 +40,7 @@ export const main = async (): Promise<void> => {
 
 	console.log('Starting repo-fetcher');
 
-	const client = getOctokit(config);
+	const client = getOctokit(config.github);
 
 	const teams = await listTeams(client);
 	console.log(`Found ${teams.length} github teams`);


### PR DESCRIPTION
## What does this change?

The config in the common package currently is specific to `repo-fetcher`, as we will want to configure the `github-lens` workspace separately move the not-common config out of `common`.

## How to test

Tests pass, repo-fetcher continues to work as expected.