### PR TITLE
Simplify reading from S3 by using transformToString

### DIFF
--- a/packages/common/src/aws/s3.test.ts
+++ b/packages/common/src/aws/s3.test.ts
@@ -4,6 +4,7 @@ import {
 	PutObjectCommand,
 	S3Client,
 } from '@aws-sdk/client-s3';
+import { sdkStreamMixin } from '@aws-sdk/util-stream-node';
 import { mockClient } from 'aws-sdk-client-mock';
 import { getObject, getS3Client, putObject } from './s3';
 
@@ -15,7 +16,7 @@ beforeEach(() => {
 
 describe('getObject', function () {
 	it('downloads and JSON parses objects stored in S3', async function () {
-		const responseBody = new Readable();
+		const responseBody = sdkStreamMixin(new Readable());
 		const expectedData = {
 			foo: 'bar',
 			bat: 'baz',

--- a/packages/common/src/aws/s3.ts
+++ b/packages/common/src/aws/s3.ts
@@ -29,15 +29,6 @@ export const putObject = async <T>(
 	console.info(`Item successfully uploaded to: s3://${bucketName}/${key}`);
 };
 
-async function streamToString(stream: Readable): Promise<string> {
-	return await new Promise((resolve, reject) => {
-		const chunks: Uint8Array[] = [];
-		stream.on('data', (chunk: Uint8Array) => chunks.push(chunk));
-		stream.on('error', reject);
-		stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
-	});
-}
-
 export const getObject = async <T>(
 	s3Client: S3Client,
 	bucketName: string,
@@ -55,7 +46,7 @@ export const getObject = async <T>(
 		throw new Error(`s3://${bucketName}/${key} is empty`);
 	}
 
-	const result = await streamToString(bodyStream as Readable);
+	const result = await bodyStream.transformToString();
 
 	console.info(`Item successfully downloaded from: s3://${bucketName}/${key}`);
 


### PR DESCRIPTION
## What does this change?

Removes the need to deal with byte arrays using [sdkStreamMixin](https://github.com/aws/aws-sdk-js-v3/issues/1877#issuecomment-1287275227).

This makes our code a bit simpler and easier to understand. It also [fixes an error in `main`](https://github.com/guardian/github-lens/actions/runs/3360557582/jobs/5569904031#step:5:39).