### PR TITLE
Output contents of repos.json on /repos

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,10 @@ const generateProject = (name) => {
 		},
 		testMatch: [`<rootDir>/packages/${name}/**/*.test.ts`],
 		setupFilesAfterEnv: [`./packages/${name}/jest.setup.js`],
+		moduleNameMapper: {
+			'^common$': '<rootDir>/packages/common/src',
+			'^common/(.*)$': '<rootDir>/packages/common/src/$1',
+		},
 	};
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17890,7 +17890,7 @@
         "esbuild": "^0.14.53",
         "eslint": "^7.29.0",
         "express": "^4.17.1",
-        "express-async-handler": "*",
+        "express-async-handler": "^1.2.0",
         "jest": "^27.0.1",
         "prettier": "^2.3.1",
         "rollup": "^2.52.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5674,6 +5674,11 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/express-async-handler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
+      "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -11334,7 +11339,8 @@
         "body-parser": "^1.19.0",
         "cors": "^2.8.5",
         "dotenv": "^10.0.0",
-        "express": "^4.17.1"
+        "express": "^4.17.1",
+        "express-async-handler": "^1.2.0"
       },
       "devDependencies": {
         "@guardian/eslint-config-typescript": "^0.6.0",
@@ -16744,7 +16750,7 @@
       "version": "file:packages/common",
       "requires": {
         "@aws-sdk/client-kms": "^3.198.0",
-        "@aws-sdk/client-s3": "*",
+        "@aws-sdk/client-s3": "^3.198.0",
         "@octokit/auth-app": "^4.0.7",
         "@octokit/plugin-throttling": "^4.1.0",
         "@octokit/rest": "^19.0.3",
@@ -17598,6 +17604,11 @@
         }
       }
     },
+    "express-async-handler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
+      "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "dev": true
@@ -17879,6 +17890,7 @@
         "esbuild": "^0.14.53",
         "eslint": "^7.29.0",
         "express": "^4.17.1",
+        "express-async-handler": "*",
         "jest": "^27.0.1",
         "prettier": "^2.3.1",
         "rollup": "^2.52.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A lens into your GitHub organisation",
   "scripts": {
     "test": "jest --detectOpenHandles",
-    "start": "npm -w packages/repo-fetcher run dev",
+    "dev-repo-fetcher": "npm -w packages/repo-fetcher run dev",
+    "dev-api": "npm -w packages/github-lens-api run dev",
     "synth": "npm run synth --workspace=cdk",
     "typecheck": "npm run typecheck --workspaces",
     "build": "npm run build --workspaces --if-present",

--- a/packages/common/src/aws/s3.ts
+++ b/packages/common/src/aws/s3.ts
@@ -1,4 +1,3 @@
-import type { Readable } from 'stream';
 import {
 	GetObjectCommand,
 	PutObjectCommand,

--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -34,6 +34,25 @@ export type TeamRepoResponse = GetResponseDataTypeFromEndpointMethod<
 >;
 export type RepositoryResponse = RepositoriesResponse[number];
 
+export interface Repository {
+	id: number;
+	name: string;
+	full_name: string;
+	private: boolean;
+	description: string | null;
+	created_at: Date | null;
+	updated_at: Date | null;
+	pushed_at: Date | null;
+	size: number | undefined;
+	language: string | null | undefined;
+	archived: boolean | undefined;
+	open_issues_count: number | undefined;
+	is_template: boolean | undefined;
+	topics: string[] | undefined;
+	default_branch: string | undefined;
+	owners: string[];
+}
+
 let _octokit: Octokit | undefined;
 
 export const getOctokit = (config: GitHubConfig): Octokit => {

--- a/packages/github-lens-api/package.json
+++ b/packages/github-lens-api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "API that exposes a snapshot of your GitHub organisation",
   "scripts": {
-    "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects repo-fetcher",
+    "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects github-lens-api",
     "prebuild": "rm -rf dist",
     "build": "esbuild src/handler.ts --bundle --outdir=dist --platform=node --target=node16 --external:aws-sdk",
     "dev": "LOCAL=true ts-node ./src/handler",

--- a/packages/github-lens-api/package.json
+++ b/packages/github-lens-api/package.json
@@ -6,7 +6,7 @@
     "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects repo-fetcher",
     "prebuild": "rm -rf dist",
     "build": "esbuild src/handler.ts --bundle --outdir=dist --platform=node --target=node16 --external:aws-sdk",
-    "dev": "LOCAL=true ts-node-dev --respawn --transpile-only src/handler.ts",
+    "dev": "LOCAL=true ts-node ./src/handler",
     "start": "npm run dev",
     "typecheck": "tsc -noEmit"
   },

--- a/packages/github-lens-api/package.json
+++ b/packages/github-lens-api/package.json
@@ -17,11 +17,12 @@
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@rollup/plugin-typescript": "^8.2.1",
     "@types/aws-serverless-express": "^3.3.3",
-    "@types/cors": "^2.8.10",
     "@types/body-parser": "^1.19.0",
+    "@types/cors": "^2.8.10",
     "@types/express": "^4.17.12",
     "@types/jest": "^27.5.0",
     "@types/supertest": "^2.0.11",
+    "esbuild": "^0.14.53",
     "eslint": "^7.29.0",
     "jest": "^27.0.1",
     "prettier": "^2.3.1",
@@ -30,16 +31,16 @@
     "ts-jest": "^27.0.3",
     "ts-node-dev": "^1.1.6",
     "tslib": "^2.3.0",
-    "typescript": "^4.3.4",
-    "esbuild": "^0.14.53"
+    "typescript": "^4.3.4"
   },
   "dependencies": {
     "@rollup/plugin-json": "^4.1.0",
     "@vendia/serverless-express": "^4.3.9",
     "aws-sdk": "^2.932.0",
     "body-parser": "^1.19.0",
+    "cors": "^2.8.5",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
-    "cors": "^2.8.5"
+    "express-async-handler": "^1.2.0"
   }
 }

--- a/packages/github-lens-api/src/app.test.ts
+++ b/packages/github-lens-api/src/app.test.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access -- For body access which is always any */
+import type { Stage } from 'common/config';
+import type { LogLevel } from 'common/log/log';
 import type { Express } from 'express';
 import request from 'supertest';
 import { buildApp } from './app';
@@ -7,7 +9,14 @@ describe('github-lens api lambda', () => {
 	let app: Express;
 
 	beforeEach(() => {
-		app = buildApp();
+		const config = {
+			dataKeyPrefix: 'prefix',
+			dataBucketName: 'bucket',
+			region: 'eu-west-1',
+			stage: 'DEV' as Stage,
+			logLevel: 'info' as LogLevel,
+		};
+		app = buildApp(config);
 	});
 
 	describe('GET /healthcheck', () => {

--- a/packages/github-lens-api/src/app.test.ts
+++ b/packages/github-lens-api/src/app.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access -- For body access which is always any */
-import type { Stage } from 'common/config';
-import type { LogLevel } from 'common/log/log';
+import type { Repository } from 'common/github/github';
 import type { Express } from 'express';
 import request from 'supertest';
 import { buildApp } from './app';
@@ -9,14 +8,8 @@ describe('github-lens api lambda', () => {
 	let app: Express;
 
 	beforeEach(() => {
-		const config = {
-			dataKeyPrefix: 'prefix',
-			dataBucketName: 'bucket',
-			region: 'eu-west-1',
-			stage: 'DEV' as Stage,
-			logLevel: 'info' as LogLevel,
-		};
-		app = buildApp(config);
+		const repoData = Promise.resolve<Repository[]>([]);
+		app = buildApp(repoData);
 	});
 
 	describe('GET /healthcheck', () => {

--- a/packages/github-lens-api/src/app.ts
+++ b/packages/github-lens-api/src/app.ts
@@ -1,10 +1,15 @@
+import path from 'path';
 import { json as jsonBodyParser } from 'body-parser';
+import { getObject, getS3Client } from 'common/aws/s3';
 import cors from 'cors';
 import express from 'express';
 import type { Express } from 'express';
+import asyncHandler from 'express-async-handler';
+import type { Config } from './config';
 
-export function buildApp(): Express {
+export function buildApp(config: Config): Express {
 	const app = express();
+	const s3Client = getS3Client(config.region);
 
 	app.use(jsonBodyParser());
 
@@ -19,9 +24,15 @@ export function buildApp(): Express {
 		res.status(200).json({ status: 'OK', stage: 'INFRA' });
 	});
 
-	app.get('/repos', (req: express.Request, res: express.Response) => {
-		res.status(200).json({});
-	});
+	app.get(
+		'/repos',
+		asyncHandler(async (req: express.Request, res: express.Response) => {
+			const repoFileLocation = path.join(config.dataKeyPrefix, 'repos.json');
+			await getObject(s3Client, config.dataBucketName, repoFileLocation);
+
+			res.status(200).json({});
+		}),
+	);
 
 	return app;
 }

--- a/packages/github-lens-api/src/app.ts
+++ b/packages/github-lens-api/src/app.ts
@@ -28,9 +28,13 @@ export function buildApp(config: Config): Express {
 		'/repos',
 		asyncHandler(async (req: express.Request, res: express.Response) => {
 			const repoFileLocation = path.join(config.dataKeyPrefix, 'repos.json');
-			await getObject(s3Client, config.dataBucketName, repoFileLocation);
+			const data = await getObject(
+				s3Client,
+				config.dataBucketName,
+				repoFileLocation,
+			);
 
-			res.status(200).json({});
+			res.status(200).json(data);
 		}),
 	);
 

--- a/packages/github-lens-api/src/app.ts
+++ b/packages/github-lens-api/src/app.ts
@@ -1,15 +1,12 @@
-import path from 'path';
 import { json as jsonBodyParser } from 'body-parser';
-import { getObject, getS3Client } from 'common/aws/s3';
+import type { Repository } from 'common/github/github';
 import cors from 'cors';
 import express from 'express';
 import type { Express } from 'express';
 import asyncHandler from 'express-async-handler';
-import type { Config } from './config';
 
-export function buildApp(config: Config): Express {
+export function buildApp(repoData: Promise<Repository[]>): Express {
 	const app = express();
-	const s3Client = getS3Client(config.region);
 
 	app.use(jsonBodyParser());
 
@@ -27,14 +24,7 @@ export function buildApp(config: Config): Express {
 	app.get(
 		'/repos',
 		asyncHandler(async (req: express.Request, res: express.Response) => {
-			const repoFileLocation = path.join(config.dataKeyPrefix, 'repos.json');
-			const data = await getObject(
-				s3Client,
-				config.dataBucketName,
-				repoFileLocation,
-			);
-
-			res.status(200).json(data);
+			res.status(200).json(await repoData);
 		}),
 	);
 

--- a/packages/github-lens-api/src/config.ts
+++ b/packages/github-lens-api/src/config.ts
@@ -1,0 +1,24 @@
+import type { Stage } from 'common/config';
+import { mandatory, optional, optionalWithDefault } from 'common/config';
+import { getLogLevel } from 'common/log/log';
+import type { LogLevel } from 'common/log/log';
+
+export type Config = {
+	dataKeyPrefix: string;
+	dataBucketName: string;
+	region: string;
+	stage: Stage;
+	logLevel: LogLevel;
+};
+
+export const getConfig = (): Config => {
+	const stage = optionalWithDefault('STAGE', 'DEV') as Stage;
+
+	return {
+		dataBucketName: mandatory('DATA_BUCKET_NAME'),
+		dataKeyPrefix: optionalWithDefault('DATA_KEY_PREFIX', stage),
+		region: optionalWithDefault('AWS_REGION', 'eu-west-1'),
+		stage,
+		logLevel: getLogLevel(optional('LOG_LEVEL')),
+	};
+};

--- a/packages/github-lens-api/src/handler.ts
+++ b/packages/github-lens-api/src/handler.ts
@@ -1,13 +1,27 @@
+import path from 'path';
 import serverlessExpress from '@vendia/serverless-express';
+import { getObject, getS3Client } from 'common/aws/s3';
+import type { Repository } from 'common/github/github';
 import { configureLogging } from 'common/log/log';
 import { buildApp } from './app';
 import { getConfig } from './config';
 
 const config = getConfig();
+const s3Client = getS3Client(config.region);
 
 configureLogging(config.logLevel);
 
-const app = buildApp(config);
+const repoFileLocation = path.join(config.dataKeyPrefix, 'repos.json');
+
+// Optimise static initialisation by creating promise to load repoData up front:
+// https://docs.aws.amazon.com/lambda/latest/operatorguide/static-initialization.html
+const repoData: Promise<Repository[]> = getObject<Repository[]>(
+	s3Client,
+	config.dataBucketName,
+	repoFileLocation,
+);
+
+const app = buildApp(repoData);
 
 if (process.env.LOCAL === 'true') {
 	const PORT = 3232;

--- a/packages/github-lens-api/src/handler.ts
+++ b/packages/github-lens-api/src/handler.ts
@@ -1,13 +1,13 @@
 import serverlessExpress from '@vendia/serverless-express';
 import { configureLogging, getLogLevel } from 'common/log/log';
-import { config as dotEnvConfig } from 'dotenv';
 import { buildApp } from './app';
+import { getConfig } from './config';
 
-configureLogging(getLogLevel(process.env['LOG_LEVEL']));
+const config = getConfig();
 
-dotEnvConfig();
+configureLogging(config.logLevel);
 
-const app = buildApp();
+const app = buildApp(config);
 
 if (process.env.LOCAL === 'true') {
 	const PORT = 3232;

--- a/packages/github-lens-api/src/handler.ts
+++ b/packages/github-lens-api/src/handler.ts
@@ -1,5 +1,5 @@
 import serverlessExpress from '@vendia/serverless-express';
-import { configureLogging, getLogLevel } from 'common/log/log';
+import { configureLogging } from 'common/log/log';
 import { buildApp } from './app';
 import { getConfig } from './config';
 

--- a/packages/repo-fetcher/src/handler.ts
+++ b/packages/repo-fetcher/src/handler.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import type { Octokit } from '@octokit/rest';
 import { getS3Client, putObject } from 'common/aws/s3';
 import {
@@ -66,7 +67,9 @@ export const main = async (): Promise<void> => {
 	);
 
 	const s3Client = getS3Client(config.region);
-	await putObject(s3Client, config.dataBucketName, config.dataKeyPrefix, repos);
+	const repoFileLocation = path.join(config.dataKeyPrefix, 'repos.json');
+
+	await putObject(s3Client, config.dataBucketName, repoFileLocation, repos);
 
 	console.log(`Finishing repo-fetcher`);
 };

--- a/packages/repo-fetcher/src/transformations.test.ts
+++ b/packages/repo-fetcher/src/transformations.test.ts
@@ -1,6 +1,6 @@
-import type { RepositoryResponse } from 'common/github/github';
+import type { Repository, RepositoryResponse } from 'common/github/github';
 import { mockRepo } from './mockRepo';
-import type { RepoAndOwner, Repository } from './transformations';
+import type { RepoAndOwner } from './transformations';
 import { asRepo, findOwnersOfRepo } from './transformations';
 
 describe('repository owners', function () {

--- a/packages/repo-fetcher/src/transformations.ts
+++ b/packages/repo-fetcher/src/transformations.ts
@@ -1,26 +1,8 @@
 import type {
+	Repository,
 	RepositoryResponse,
 	TeamRepoResponse,
 } from 'common/github/github';
-
-export interface Repository {
-	id: number;
-	name: string;
-	full_name: string;
-	private: boolean;
-	description: string | null;
-	created_at: Date | null;
-	updated_at: Date | null;
-	pushed_at: Date | null;
-	size: number | undefined;
-	language: string | null | undefined;
-	archived: boolean | undefined;
-	open_issues_count: number | undefined;
-	is_template: boolean | undefined;
-	topics: string[] | undefined;
-	default_branch: string | undefined;
-	owners: string[];
-}
 
 const parseDateString = (
 	dateString: string | null | undefined,


### PR DESCRIPTION
## What does this change?

This change returns the contents of the `repos.json` stored by repo-fetcher on the `/repos` endpoint in the `github-lens-api` endpoint. This allows the repo data to be read from the API!

<img width="874" alt="Screenshot 2022-11-01 at 11 38 06" src="https://user-images.githubusercontent.com/953792/199224564-d5e1b2f8-55ec-4ace-864d-a0b3f80cff3e.png">

## How to test

Tests pass, after infra deployed the `/repos` endpoint will return data.