### PR TITLE
Add router describing request handler

### DIFF
--- a/packages/github-lens-api/src/app.ts
+++ b/packages/github-lens-api/src/app.ts
@@ -1,32 +1,38 @@
 import { json as jsonBodyParser } from 'body-parser';
 import type { Repository } from 'common/github/github';
 import cors from 'cors';
-import express from 'express';
 import type { Express } from 'express';
+import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
+import { getDescribeRouterHandler } from './expressRoutes';
 
 export function buildApp(repoData: Promise<Repository[]>): Express {
 	const app = express();
+	const router = Router();
 
-	app.use(jsonBodyParser());
+	router.use(jsonBodyParser());
 
-	app.use(
+	router.use(
 		cors({
 			origin: /\.(dev-)?gutools.co.uk$/,
 			credentials: true,
 		}),
 	);
 
-	app.get('/healthcheck', (req: express.Request, res: express.Response) => {
+	router.get('/', getDescribeRouterHandler(router));
+
+	router.get('/healthcheck', (req: express.Request, res: express.Response) => {
 		res.status(200).json({ status: 'OK', stage: 'INFRA' });
 	});
 
-	app.get(
+	router.get(
 		'/repos',
 		asyncHandler(async (req: express.Request, res: express.Response) => {
 			res.status(200).json(await repoData);
 		}),
 	);
+
+	app.use('/', router);
 
 	return app;
 }

--- a/packages/github-lens-api/src/expressRoutes.ts
+++ b/packages/github-lens-api/src/expressRoutes.ts
@@ -27,4 +27,4 @@ export const getDescribeRouterHandler = (router: Router) => {
 
 		res.status(200).json(stack);
 	};
-}
+};

--- a/packages/github-lens-api/src/expressRoutes.ts
+++ b/packages/github-lens-api/src/expressRoutes.ts
@@ -1,0 +1,30 @@
+import type { Router } from 'express';
+import type express from 'express';
+
+interface InnerLayer {
+	method: string;
+}
+
+interface InnerRoute {
+	path: string;
+	stack: InnerLayer[];
+}
+
+interface RouterLayer {
+	route: InnerRoute | undefined;
+}
+
+export const getDescribeRouterHandler = (router: Router) => {
+	return (req: express.Request, res: express.Response) => {
+		const stack = router.stack
+			.filter((layer: RouterLayer) => layer.route != undefined)
+			.map((layer: RouterLayer) => {
+				return {
+					path: layer.route?.path,
+					methods: layer.route?.stack.map((innerStack) => innerStack.method),
+				};
+			});
+
+		res.status(200).json(stack);
+	};
+}


### PR DESCRIPTION
## What does this change?

This change adds a special request handler that can parse the Express routing stack and report a list of endpoints with their methods.

Requesting `/` will return the following:

```json
[
  {
    "path": "/",
    "methods": [
      "get"
    ]
  },
  {
    "path": "/healthcheck",
    "methods": [
      "get"
    ]
  },
  {
    "path": "/repos",
    "methods": [
      "get"
    ]
  }
]
```

This is intended to make it easier for developers or folk working with the API to discover and browse endpoints in this service.