### PR TITLE
Add last-modified date to the data retrieved from S3

### DIFF
--- a/packages/common/src/aws/s3.test.ts
+++ b/packages/common/src/aws/s3.test.ts
@@ -17,22 +17,29 @@ beforeEach(() => {
 describe('getObject', function () {
 	it('downloads and JSON parses objects stored in S3', async function () {
 		const responseBody = sdkStreamMixin(new Readable());
-		const expectedData = {
+		const expectedDate = new Date('01/01/2020');
+
+		const expectedPayload = {
 			foo: 'bar',
 			bat: 'baz',
 		};
+		const expectedRetrievedObject = {
+			payload: expectedPayload,
+			lastModified: expectedDate,
+		};
 
-		responseBody.push(JSON.stringify(expectedData));
+		responseBody.push(JSON.stringify(expectedPayload));
 		responseBody.push(null);
 
 		s3Mock.on(GetObjectCommand).resolves({
 			Body: responseBody,
+			LastModified: expectedDate,
 		});
 
 		const s3Client = getS3Client('eu-west-1');
-		const actualData = await getObject(s3Client, 'bucket', 'key');
+		const retrievedObject = await getObject(s3Client, 'bucket', 'key');
 
-		expect(expectedData).toStrictEqual(actualData);
+		expect(expectedRetrievedObject).toStrictEqual(retrievedObject);
 	});
 });
 

--- a/packages/common/src/aws/s3.ts
+++ b/packages/common/src/aws/s3.ts
@@ -28,11 +28,16 @@ export const putObject = async <T>(
 	console.info(`Item successfully uploaded to: s3://${bucketName}/${key}`);
 };
 
+export interface RetrievedObject<T> {
+	payload: T;
+	lastModified?: Date;
+}
+
 export const getObject = async <T>(
 	s3Client: S3Client,
 	bucketName: string,
 	key: string,
-): Promise<T> => {
+): Promise<RetrievedObject<T>> => {
 	const command = new GetObjectCommand({
 		Bucket: bucketName,
 		Key: key,
@@ -40,6 +45,7 @@ export const getObject = async <T>(
 
 	const response = await s3Client.send(command);
 	const bodyStream = response.Body;
+	const lastModified = response.LastModified;
 
 	if (!bodyStream) {
 		throw new Error(`s3://${bucketName}/${key} is empty`);
@@ -49,5 +55,10 @@ export const getObject = async <T>(
 
 	console.info(`Item successfully downloaded from: s3://${bucketName}/${key}`);
 
-	return JSON.parse(result) as T;
+	const payload = JSON.parse(result) as T;
+
+	return {
+		payload,
+		lastModified,
+	};
 };

--- a/packages/github-lens-api/src/app.test.ts
+++ b/packages/github-lens-api/src/app.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access -- For body access which is always any */
+import type { RetrievedObject } from 'common/aws/s3';
 import type { Repository } from 'common/github/github';
 import type { Express } from 'express';
 import request from 'supertest';
@@ -8,7 +9,9 @@ describe('github-lens api lambda', () => {
 	let app: Express;
 
 	beforeEach(() => {
-		const repoData = Promise.resolve<Repository[]>([]);
+		const repoData = Promise.resolve<RetrievedObject<Repository[]>>({
+			payload: [],
+		});
 		app = buildApp(repoData);
 	});
 

--- a/packages/github-lens-api/src/app.ts
+++ b/packages/github-lens-api/src/app.ts
@@ -1,11 +1,14 @@
 import { json as jsonBodyParser } from 'body-parser';
+import type { RetrievedObject } from 'common/aws/s3';
 import type { Repository } from 'common/github/github';
 import cors from 'cors';
 import express from 'express';
 import type { Express } from 'express';
 import asyncHandler from 'express-async-handler';
 
-export function buildApp(repoData: Promise<Repository[]>): Express {
+export function buildApp(
+	repoData: Promise<RetrievedObject<Repository[]>>,
+): Express {
 	const app = express();
 
 	app.use(jsonBodyParser());

--- a/packages/github-lens-api/src/handler.ts
+++ b/packages/github-lens-api/src/handler.ts
@@ -15,7 +15,7 @@ const repoFileLocation = path.join(config.dataKeyPrefix, 'repos.json');
 
 // Optimise static initialisation by creating promise to load repoData up front:
 // https://docs.aws.amazon.com/lambda/latest/operatorguide/static-initialization.html
-const repoData: Promise<Repository[]> = getObject<Repository[]>(
+const repoData = getObject<Repository[]>(
 	s3Client,
 	config.dataBucketName,
 	repoFileLocation,


### PR DESCRIPTION
## What does this change?

This change adds a `lastModified` field to the object returned from S3 using the `RetrievedObject` interface.

The last modified date is determined from the S3 metadata for a retrieved object.

The intention is to improve the usefulness of the data returned from the API i.e.f if the data in S3 hasn't been refreshed it's useful to know that!

The API response looks like this:

<img width="780" alt="Screenshot 2022-11-02 at 15 30 31" src="https://user-images.githubusercontent.com/953792/199531747-1ef54db8-d4d6-412c-acb6-982867d7076c.png">

**Note:** In a future PR we may want to introduce a separate response type and parse the `RetrievedObject` into that type. 

## How to test

`npm run test`