### PR TITLE
full url to be able to click on link in api description

### DIFF
--- a/packages/github-lens-api/src/expressRoutes.ts
+++ b/packages/github-lens-api/src/expressRoutes.ts
@@ -1,3 +1,4 @@
+import { strict } from 'assert';
 import type { Router } from 'express';
 import type express from 'express';
 
@@ -16,11 +17,14 @@ interface RouterLayer {
 
 export const getDescribeRouterHandler = (router: Router) => {
 	return (req: express.Request, res: express.Response) => {
+		const urlProtocol = req.protocol + '://';
+		const urlHost = req.get('host') ?? 'localhost:3232';
 		const stack = router.stack
 			.filter((layer: RouterLayer) => layer.route != undefined)
 			.map((layer: RouterLayer) => {
+				const path = layer.route?.path ?? '';
 				return {
-					path: layer.route?.path,
+					path: urlProtocol + urlHost + path,
 					methods: layer.route?.stack.map((innerStack) => innerStack.method),
 				};
 			});

--- a/packages/github-lens-api/src/expressRoutes.ts
+++ b/packages/github-lens-api/src/expressRoutes.ts
@@ -1,4 +1,3 @@
-import { strict } from 'assert';
 import type { Router } from 'express';
 import type express from 'express';
 


### PR DESCRIPTION
## What does this change?

Add full url to be able to click on the link in the api description (e. g. http://localhost:3232/healthcheck)