### PR TITLE
Return 404 when path not found

### DIFF
--- a/packages/common/src/expressRoutes.ts
+++ b/packages/common/src/expressRoutes.ts
@@ -31,6 +31,6 @@ export const getDescribeRouterHandler = (router: Router) => {
 				};
 			});
 
-		res.status(200).json(stack);
+		res.status(404).json(stack);
 	};
 };

--- a/packages/github-lens-api/src/app.ts
+++ b/packages/github-lens-api/src/app.ts
@@ -22,8 +22,6 @@ export function buildApp(
 		}),
 	);
 
-	router.get('/', getDescribeRouterHandler(router));
-
 	router.get('/healthcheck', (req: express.Request, res: express.Response) => {
 		res.status(200).json({ status: 'OK', stage: 'INFRA' });
 	});


### PR DESCRIPTION
## What does this change?

`getDescribeRouterHandler` is used to list available routes when a user provides a path that is not found. This change returns the correct status code for not found routes (404).

