### PR TITLE
Add teams data

### DIFF
--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -26,6 +26,9 @@ const octokit = new Octokit();
 export type RepositoriesResponse = GetResponseDataTypeFromEndpointMethod<
 	typeof octokit.repos.listForOrg
 >;
+export type GetTeamByNameResponse = GetResponseDataTypeFromEndpointMethod<
+	typeof octokit.teams.getByName
+>;
 export type TeamsResponse = GetResponseDataTypeFromEndpointMethod<
 	typeof octokit.teams.list
 >;
@@ -90,6 +93,18 @@ export const listRepositories = async (
 		},
 		(response) => response.data,
 	);
+};
+
+export const getTeam = async (
+	client: Octokit,
+	teamName: string,
+): Promise<GetTeamByNameResponse> => {
+	const getTeamResponse = await client.teams.getByName({
+		org: 'guardian',
+		team_slug: teamName,
+	});
+
+	return getTeamResponse.data;
 };
 
 export const listTeams = async (client: Octokit): Promise<TeamsResponse> => {

--- a/packages/common/src/model/repository.ts
+++ b/packages/common/src/model/repository.ts
@@ -16,3 +16,10 @@ export interface Repository {
 	default_branch: string | undefined;
 	owners: string[];
 }
+
+export interface Team {
+	id: number;
+	name: string;
+	slug: string;
+	repos: Repository[];
+}

--- a/packages/github-lens-api/src/app.test.ts
+++ b/packages/github-lens-api/src/app.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access -- For body access which is always any */
 import type { RetrievedObject } from 'common/aws/s3';
-import type { Repository } from 'common/model/repository';
+import type { Repository, Team } from 'common/model/repository';
 import type { Express } from 'express';
 import request from 'supertest';
 import { buildApp } from './app';
@@ -12,7 +12,10 @@ describe('github-lens api lambda', () => {
 		const repoData = Promise.resolve<RetrievedObject<Repository[]>>({
 			payload: [],
 		});
-		app = buildApp(repoData);
+		const teamData = Promise.resolve<RetrievedObject<Team[]>>({
+			payload: [],
+		});
+		app = buildApp(repoData, teamData);
 	});
 
 	describe('GET /healthcheck', () => {

--- a/packages/github-lens-api/src/app.ts
+++ b/packages/github-lens-api/src/app.ts
@@ -1,6 +1,6 @@
 import { json as jsonBodyParser } from 'body-parser';
 import type { RetrievedObject } from 'common/aws/s3';
-import type { Repository } from 'common/model/repository';
+import type { Repository, Team } from 'common/model/repository';
 import cors from 'cors';
 import type { Express } from 'express';
 import express, { Router } from 'express';
@@ -9,6 +9,7 @@ import { getDescribeRouterHandler } from '../../common/src/expressRoutes';
 
 export function buildApp(
 	repoData: Promise<RetrievedObject<Repository[]>>,
+	teamData: Promise<RetrievedObject<Team[]>>,
 ): Express {
 	const app = express();
 	const router = Router();
@@ -49,6 +50,31 @@ export function buildApp(
 			const reposData = await repoData;
 			const jsonResponse = reposData.payload.filter(
 				(item) => item.name === req.params.name,
+			);
+			if (jsonResponse.length !== 0) {
+				res.status(200).json(jsonResponse);
+			} else {
+				res
+					.status(200)
+					.json({ repoName: req.params.name, info: 'Repo not found' });
+			}
+		}),
+	);
+
+	router.get(
+		'/teams',
+		asyncHandler(async (req: express.Request, res: express.Response) => {
+			const teamsData = await teamData;
+			res.status(200).json(teamsData);
+		}),
+	);
+
+	router.get(
+		'/teams/:name',
+		asyncHandler(async (req: express.Request, res: express.Response) => {
+			const teamsData = await teamData;
+			const jsonResponse = teamsData.payload.filter(
+				(item) => item.slug === req.params.name,
 			);
 			if (jsonResponse.length !== 0) {
 				res.status(200).json(jsonResponse);

--- a/packages/github-lens-api/src/handler.ts
+++ b/packages/github-lens-api/src/handler.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { getObject, getS3Client } from 'common/aws/s3';
 import { configureLogging } from 'common/log/log';
-import type { Repository } from 'common/model/repository';
+import type { Repository, Team } from 'common/model/repository';
 import { buildApp } from './app';
 import { getConfig } from './config';
 
@@ -11,16 +11,21 @@ const s3Client = getS3Client(config.region);
 configureLogging(config.logLevel);
 
 const repoFileLocation = path.join(config.dataKeyPrefix, 'repos.json');
+const teamFileLocation = path.join(config.dataKeyPrefix, 'teams.json');
 
-// Optimise static initialisation by creating promise to load repoData up front:
-// https://docs.aws.amazon.com/lambda/latest/operatorguide/static-initialization.html
 const repoData = getObject<Repository[]>(
 	s3Client,
 	config.dataBucketName,
 	repoFileLocation,
 );
 
-const app = buildApp(repoData);
+const teamData = getObject<Team[]>(
+	s3Client,
+	config.dataBucketName,
+	teamFileLocation,
+);
+
+const app = buildApp(repoData, teamData);
 
 const PORT = process.env.PORT ?? '3232';
 app.listen(PORT, () => {

--- a/packages/repo-fetcher/src/handler.ts
+++ b/packages/repo-fetcher/src/handler.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import { S3Client } from '@aws-sdk/client-s3';
 import type { Octokit } from '@octokit/rest';
 import { getS3Client, putObject } from 'common/aws/s3';
 import {

--- a/packages/repo-fetcher/src/handler.ts
+++ b/packages/repo-fetcher/src/handler.ts
@@ -1,13 +1,16 @@
 import path from 'path';
+import { S3Client } from '@aws-sdk/client-s3';
 import type { Octokit } from '@octokit/rest';
 import { getS3Client, putObject } from 'common/aws/s3';
 import {
 	getOctokit,
 	getReposForTeam,
+	getTeam,
 	listRepositories,
 	listTeams,
 } from 'common/github/github';
 import { configureLogging, getLogLevel } from 'common/log/log';
+import type { Repository, Team } from 'common/model/repository';
 import { getConfig } from './config';
 import { asRepo, getAdminReposFromResponse } from './transformations';
 
@@ -34,16 +37,69 @@ const teamRepositories = async (
 	}, {});
 };
 
-async function getTeamNames(
+export interface TeamsAndRepositories {
+	teams: Team[];
+	repos: Repository[];
+}
+
+async function getTeamsAndRepositories(
 	client: Octokit,
 	teamName?: string,
-): Promise<string[]> {
-	if (teamName) {
-		return Promise.resolve([teamName]);
-	}
+): Promise<TeamsAndRepositories> {
+	const teams = teamName
+		? [await getTeam(client, teamName)]
+		: await listTeams(client);
 
-	const allTeams = await listTeams(client);
-	return allTeams.map((_) => _.slug);
+	console.log(`Found ${teams.length} github teams`);
+
+	const repositories = await listRepositories(client);
+
+	console.log(`Found ${repositories.length} github repos`);
+
+	const repositoriesToAdmins = await teamRepositories(
+		client,
+		teams.map((_) => _.slug),
+	);
+
+	const repositoriesOutput = repositories.map((repository) =>
+		asRepo(repository, repositoriesToAdmins[repository.name] ?? []),
+	);
+
+	const teamsMap = repositories.reduce<
+		Record<string, Repository[] | undefined>
+	>((acc, repository) => {
+		const adminTeamSlugs = repositoriesToAdmins[repository.name] ?? [];
+		const repo = asRepo(
+			repository,
+			repositoriesToAdmins[repository.name] ?? [],
+		);
+
+		adminTeamSlugs.forEach((adminSlug: string) => {
+			if (acc[adminSlug] == undefined) {
+				acc[adminSlug] = [repo];
+			} else {
+				acc[adminSlug]?.push(repo);
+			}
+		});
+
+		return acc;
+	}, {});
+
+	const teamsOutput = teams.map((team): Team => {
+		const repos = teamsMap[team.slug];
+
+		return {
+			id: team.id,
+			name: team.name,
+			slug: team.slug,
+			repos: repos ?? [],
+		};
+	});
+
+	return {
+		teams: teamsOutput,
+		repos: repositoriesOutput,
+	};
 }
 
 export const main = async (): Promise<void> => {
@@ -52,24 +108,21 @@ export const main = async (): Promise<void> => {
 
 	console.log('Starting repo-fetcher');
 
-	const client = getOctokit(config.github);
+	const githubClient = getOctokit(config.github);
+	const s3Client = getS3Client(config.region);
 
-	const teamNames = await getTeamNames(client, config.github.teamToFetch);
-	console.log(`Found ${teamNames.length} github teams`);
-
-	const repositories = await listRepositories(client);
-	console.log(`Found ${repositories.length} github repos`);
-
-	const repositoriesToAdmins = await teamRepositories(client, teamNames);
-
-	const repos = repositories.map((repository) =>
-		asRepo(repository, repositoriesToAdmins[repository.name] ?? []),
+	const teamsAndRepos = await getTeamsAndRepositories(
+		githubClient,
+		config.github.teamToFetch,
 	);
 
-	const s3Client = getS3Client(config.region);
-	const repoFileLocation = path.join(config.dataKeyPrefix, 'repos.json');
+	const saveObject = async <T>(name: string, data: T) => {
+		const repoFileLocation = path.join(config.dataKeyPrefix, `${name}.json`);
+		await putObject(s3Client, config.dataBucketName, repoFileLocation, data);
+	};
 
-	await putObject(s3Client, config.dataBucketName, repoFileLocation, repos);
+	await saveObject('repos', teamsAndRepos.repos);
+	await saveObject('teams', teamsAndRepos.teams);
 
 	console.log(`Finishing repo-fetcher`);
 };

--- a/packages/repo-fetcher/src/transformations.ts
+++ b/packages/repo-fetcher/src/transformations.ts
@@ -19,7 +19,7 @@ const parseDateString = (
 
 export const asRepo = (
 	repo: RepositoryResponse,
-	owners: string[],
+	owners?: string[],
 ): Repository => {
 	return {
 		id: repo.id,
@@ -37,7 +37,7 @@ export const asRepo = (
 		is_template: repo.is_template,
 		topics: repo.topics,
 		default_branch: repo.default_branch,
-		owners: owners,
+		owners: owners ? owners : [],
 	};
 };
 


### PR DESCRIPTION
## What does this change?

This change stores a list of teams in S3 along with the repositories they own so this data can be made available in the github-lens API.  It also adds `/teams` and `/teams/:name` endpoints.

<img width="626" alt="Screenshot 2022-11-24 at 10 40 17" src="https://user-images.githubusercontent.com/953792/203763785-cbca457f-eced-4561-b698-d5153f258215.png">


## Why?

More complete view on GitHub, and this data can then be used by `services.gutools` to identify which P&E teams own which repositories.