### PR TITLE
chore(deps): Remove unused aws-sdk@v2 dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5848,6 +5848,7 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5858,6 +5859,7 @@
     },
     "node_modules/aws-sdk": {
       "version": "2.1209.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "buffer": "4.9.2",
@@ -5982,6 +5984,7 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6111,6 +6114,7 @@
     },
     "node_modules/buffer": {
       "version": "4.9.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.0.2",
@@ -6496,6 +6500,7 @@
     },
     "node_modules/define-properties": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
@@ -6673,6 +6678,7 @@
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
       "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -6717,6 +6723,7 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.4",
@@ -7533,6 +7540,7 @@
     },
     "node_modules/events": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.x"
@@ -7855,6 +7863,7 @@
     },
     "node_modules/for-each": {
       "version": "0.3.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
@@ -7947,6 +7956,7 @@
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -7969,6 +7979,7 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8021,6 +8032,7 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -8147,6 +8159,7 @@
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8161,6 +8174,7 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.1"
@@ -8181,6 +8195,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -8252,6 +8267,7 @@
     },
     "node_modules/ieee754": {
       "version": "1.1.13",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
@@ -8325,6 +8341,7 @@
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.0",
@@ -8344,6 +8361,7 @@
     },
     "node_modules/is-arguments": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -8362,6 +8380,7 @@
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.1"
@@ -8372,6 +8391,7 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -8388,6 +8408,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -8408,6 +8429,7 @@
     },
     "node_modules/is-date-object": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -8458,6 +8480,7 @@
     },
     "node_modules/is-generator-function": {
       "version": "1.0.10",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -8482,6 +8505,7 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8499,6 +8523,7 @@
     },
     "node_modules/is-number-object": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -8529,6 +8554,7 @@
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -8543,6 +8569,7 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
@@ -8572,6 +8599,7 @@
     },
     "node_modules/is-string": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -8585,6 +8613,7 @@
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -8598,6 +8627,7 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
@@ -8615,6 +8645,7 @@
     },
     "node_modules/is-weakref": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
@@ -8636,6 +8667,7 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -9277,6 +9309,7 @@
     },
     "node_modules/jmespath": {
       "version": "0.16.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.6.0"
@@ -9773,6 +9806,7 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9790,6 +9824,7 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
       "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -10260,6 +10295,7 @@
     },
     "node_modules/querystring": {
       "version": "0.2.0",
+      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -10412,6 +10448,7 @@
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -10552,6 +10589,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
       "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -10567,6 +10605,7 @@
     },
     "node_modules/sax": {
       "version": "1.2.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/semver": {
@@ -10819,6 +10858,7 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -10831,6 +10871,7 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -11232,6 +11273,7 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -11306,6 +11348,7 @@
     },
     "node_modules/url": {
       "version": "0.10.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "1.3.2",
@@ -11314,10 +11357,12 @@
     },
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/util": {
       "version": "0.12.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -11337,6 +11382,7 @@
     },
     "node_modules/uuid": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -11410,6 +11456,7 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.0.1",
@@ -11424,6 +11471,7 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
@@ -11493,6 +11541,7 @@
     },
     "node_modules/xml2js": {
       "version": "0.4.19",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
@@ -11501,6 +11550,7 @@
     },
     "node_modules/xmlbuilder": {
       "version": "9.0.7",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
@@ -11953,7 +12003,6 @@
     "packages/github-lens-api": {
       "version": "0.0.1",
       "dependencies": {
-        "aws-sdk": "^2.932.0",
         "body-parser": "^1.19.0",
         "cors": "^2.8.5",
         "dotenv": "^10.0.0",
@@ -16546,10 +16595,12 @@
       "dev": true
     },
     "available-typed-arrays": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "dev": true
     },
     "aws-sdk": {
       "version": "2.1209.0",
+      "dev": true,
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -16647,7 +16698,8 @@
       "version": "1.0.2"
     },
     "base64-js": {
-      "version": "1.5.1"
+      "version": "1.5.1",
+      "dev": true
     },
     "before-after-hook": {
       "version": "2.2.2"
@@ -16727,6 +16779,7 @@
     },
     "buffer": {
       "version": "4.9.2",
+      "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -17241,6 +17294,7 @@
     },
     "define-properties": {
       "version": "1.1.4",
+      "dev": true,
       "requires": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
@@ -17350,6 +17404,7 @@
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
       "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -17388,6 +17443,7 @@
     },
     "es-to-primitive": {
       "version": "1.2.1",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -17889,7 +17945,8 @@
       "version": "1.8.1"
     },
     "events": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "execa": {
       "version": "5.1.1",
@@ -18133,6 +18190,7 @@
     },
     "for-each": {
       "version": "0.3.3",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.3"
       }
@@ -18190,6 +18248,7 @@
     },
     "function.prototype.name": {
       "version": "1.1.5",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -18204,7 +18263,8 @@
       "dev": true
     },
     "functions-have-names": {
-      "version": "1.2.3"
+      "version": "1.2.3",
+      "dev": true
     },
     "gensync": {
       "version": "1.0.0-beta.2"
@@ -18232,6 +18292,7 @@
     },
     "get-symbol-description": {
       "version": "1.0.0",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -18250,7 +18311,6 @@
         "@types/cors": "^2.8.10",
         "@types/express": "^4.17.12",
         "@types/supertest": "^2.0.11",
-        "aws-sdk": "^2.932.0",
         "body-parser": "^1.19.0",
         "cors": "^2.8.5",
         "dotenv": "^10.0.0",
@@ -18336,13 +18396,15 @@
       }
     },
     "has-bigints": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "has-flag": {
       "version": "4.0.0"
     },
     "has-property-descriptors": {
       "version": "1.0.0",
+      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.1"
       }
@@ -18352,6 +18414,7 @@
     },
     "has-tostringtag": {
       "version": "1.0.0",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -18395,7 +18458,8 @@
       }
     },
     "ieee754": {
-      "version": "1.1.13"
+      "version": "1.1.13",
+      "dev": true
     },
     "ignore": {
       "version": "5.2.0",
@@ -18438,6 +18502,7 @@
     },
     "internal-slot": {
       "version": "1.0.3",
+      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
@@ -18449,6 +18514,7 @@
     },
     "is-arguments": {
       "version": "1.1.1",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -18459,12 +18525,14 @@
     },
     "is-bigint": {
       "version": "1.0.4",
+      "dev": true,
       "requires": {
         "has-bigints": "^1.0.1"
       }
     },
     "is-boolean-object": {
       "version": "1.1.2",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -18473,7 +18541,8 @@
     "is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true
     },
     "is-core-module": {
       "version": "2.11.0",
@@ -18485,6 +18554,7 @@
     },
     "is-date-object": {
       "version": "1.0.5",
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -18507,6 +18577,7 @@
     },
     "is-generator-function": {
       "version": "1.0.10",
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -18519,13 +18590,15 @@
       }
     },
     "is-negative-zero": {
-      "version": "2.0.2"
+      "version": "2.0.2",
+      "dev": true
     },
     "is-number": {
       "version": "7.0.0"
     },
     "is-number-object": {
       "version": "1.0.7",
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -18542,6 +18615,7 @@
     },
     "is-regex": {
       "version": "1.1.4",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -18549,6 +18623,7 @@
     },
     "is-shared-array-buffer": {
       "version": "1.0.2",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -18567,18 +18642,21 @@
     },
     "is-string": {
       "version": "1.0.7",
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
     },
     "is-symbol": {
       "version": "1.0.4",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
     },
     "is-typed-array": {
       "version": "1.1.9",
+      "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -18589,6 +18667,7 @@
     },
     "is-weakref": {
       "version": "1.0.2",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -18601,7 +18680,8 @@
       }
     },
     "isarray": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0"
@@ -19089,7 +19169,8 @@
       }
     },
     "jmespath": {
-      "version": "0.16.0"
+      "version": "0.16.0",
+      "dev": true
     },
     "js-sdsl": {
       "version": "4.2.0",
@@ -19425,7 +19506,8 @@
       "version": "1.12.2"
     },
     "object-keys": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "object-treeify": {
       "version": "1.1.33",
@@ -19435,6 +19517,7 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
       "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -19727,7 +19810,8 @@
       }
     },
     "querystring": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "dev": true
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -19819,6 +19903,7 @@
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -19903,6 +19988,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
       "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -19913,7 +19999,8 @@
       "version": "2.1.2"
     },
     "sax": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "dev": true
     },
     "semver": {
       "version": "7.3.7",
@@ -20120,6 +20207,7 @@
     },
     "string.prototype.trimend": {
       "version": "1.0.5",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -20128,6 +20216,7 @@
     },
     "string.prototype.trimstart": {
       "version": "1.0.5",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -20369,6 +20458,7 @@
     },
     "unbox-primitive": {
       "version": "1.0.2",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
@@ -20412,18 +20502,21 @@
     },
     "url": {
       "version": "0.10.3",
+      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
       },
       "dependencies": {
         "punycode": {
-          "version": "1.3.2"
+          "version": "1.3.2",
+          "dev": true
         }
       }
     },
     "util": {
       "version": "0.12.4",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -20437,7 +20530,8 @@
       "version": "1.0.1"
     },
     "uuid": {
-      "version": "8.0.0"
+      "version": "8.0.0",
+      "dev": true
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1"
@@ -20489,6 +20583,7 @@
     },
     "which-boxed-primitive": {
       "version": "1.0.2",
+      "dev": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -20499,6 +20594,7 @@
     },
     "which-typed-array": {
       "version": "1.1.8",
+      "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -20542,13 +20638,15 @@
     },
     "xml2js": {
       "version": "0.4.19",
+      "dev": true,
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
-      "version": "9.0.7"
+      "version": "9.0.7",
+      "dev": true
     },
     "y18n": {
       "version": "5.0.8"

--- a/packages/github-lens-api/package.json
+++ b/packages/github-lens-api/package.json
@@ -18,7 +18,6 @@
     "supertest": "^6.1.3"
   },
   "dependencies": {
-    "aws-sdk": "^2.932.0",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "dotenv": "^10.0.0",


### PR DESCRIPTION
## What does this change?
Removes an unused dependency.

## Why?
The dependency `aws-sdk@2.932.0` is unused and can be removed.

The github-lens-api project doesn't used aws-sdk directly, it uses it via common, and [common uses aws-sdk@v3](https://github.com/guardian/github-lens/blob/e5358953a7c05b018b19de1cb5ef0bb6036c6b19/packages/common/package.json#L8-L9).